### PR TITLE
feat: add logging system to observe simulation events

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ See [project_spec.md](project_spec.md) for the full specification, architecture 
 
 An example configuration file `example_farm.json` demonstrates a minimal world setup loaded via the declarative loader.
 
+The engine includes a `LoggingSystem` that prints selected events, offering a basic way to observe simulations from the console.
+
 ## Development
 
 * Python 3.9+

--- a/example_farm.json
+++ b/example_farm.json
@@ -21,7 +21,8 @@
         ]
       },
       {"type": "TimeSystem", "id": "time"},
-      {"type": "EconomySystem", "id": "economy"}
+      {"type": "EconomySystem", "id": "economy"},
+      {"type": "LoggingSystem", "id": "logger"}
     ]
   }
 }

--- a/project_spec.md
+++ b/project_spec.md
@@ -172,7 +172,7 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Implement `CharacterNode` composed of generic nodes and simple farmer logic.
 - [x] Create minimal farm simulation configuration file.
 - [x] Write integration tests for farmer working, eating and sleeping.
-- [ ] Provide minimal rendering/logging to observe the simulation.
+- [x] Provide minimal rendering/logging to observe the simulation (LoggingSystem outputs events to console).
 - [x] Document architecture and nodes, update README.
 - [ ] Implement seed-based reproducibility (optional).
 - [x] Prepare foundations for future plugins and scenarios.

--- a/systems/logger.py
+++ b/systems/logger.py
@@ -1,0 +1,50 @@
+"""Event logging system."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Optional
+
+from core.simnode import SystemNode
+from core.plugins import register_node_type
+
+
+class LoggingSystem(SystemNode):
+    """Log specified events for observation.
+
+    Parameters
+    ----------
+    events:
+        Iterable of event names to log. If ``None``, a default set of
+        common events is used.
+    logger:
+        Optional :class:`logging.Logger` instance. Defaults to one named
+        after the system.
+    """
+
+    DEFAULT_EVENTS = [
+        "tick",
+        "phase_changed",
+        "inventory_changed",
+        "resource_produced",
+        "need_threshold_reached",
+        "need_satisfied",
+    ]
+
+    def __init__(
+        self,
+        events: Optional[Iterable[str]] = None,
+        logger: Optional[logging.Logger] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.logger = logger or logging.getLogger(self.name)
+        self.events = list(events) if events is not None else list(self.DEFAULT_EVENTS)
+        for event in self.events:
+            self.on_event(event, self._log_event)
+
+    def _log_event(self, origin, event_name, payload) -> None:
+        """Log an incoming event."""
+        self.logger.info("%s from %s: %s", event_name, origin.name, payload)
+
+
+register_node_type("LoggingSystem", LoggingSystem)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,16 @@
+import logging
+
+from nodes.world import WorldNode
+from nodes.character import CharacterNode
+from nodes.need import NeedNode
+from systems.logger import LoggingSystem
+
+
+def test_logging_system_records_events(caplog):
+    world = WorldNode(name="world")
+    char = CharacterNode(name="char", parent=world)
+    need = NeedNode(name="hunger", threshold=1, increase_rate=2, parent=char)
+    logger_sys = LoggingSystem(parent=world, events=["need_threshold_reached"])
+    with caplog.at_level(logging.INFO, logger=logger_sys.logger.name):
+        world.update(1)
+    assert any("need_threshold_reached" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- add `LoggingSystem` to log key events through Python logging
- expose logging system in example configuration and docs
- cover logging with unit test and mark roadmap checklist

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893c40d166483308b5e7223bbc7c7c4