### PR TITLE
Add Pygame viewer system for on-screen simulation

### DIFF
--- a/example_farm.json
+++ b/example_farm.json
@@ -22,7 +22,8 @@
       },
       {"type": "TimeSystem", "id": "time"},
       {"type": "EconomySystem", "id": "economy"},
-      {"type": "LoggingSystem", "id": "logger"}
+      {"type": "LoggingSystem", "id": "logger"},
+      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 400, "height": 300}}
     ]
   }
 }

--- a/project_spec.md
+++ b/project_spec.md
@@ -173,6 +173,7 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Create minimal farm simulation configuration file.
 - [x] Write integration tests for farmer working, eating and sleeping.
 - [x] Provide minimal rendering/logging to observe the simulation (LoggingSystem outputs events to console).
+- [x] Add Pygame-based visualization interface.
 - [x] Document architecture and nodes, update README.
 - [ ] Implement seed-based reproducibility (optional).
 - [x] Prepare foundations for future plugins and scenarios.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=6.0
+pygame>=2.0

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -1,0 +1,87 @@
+"""Pygame-based viewer system to visualise simulation state."""
+from __future__ import annotations
+
+import os
+from typing import Iterator, List
+
+import pygame
+
+from core.simnode import SystemNode
+from core.plugins import register_node_type
+from nodes.inventory import InventoryNode
+from nodes.need import NeedNode
+from nodes.transform import TransformNode
+
+
+class PygameViewerSystem(SystemNode):
+    """Render simulation state using a simple Pygame window.
+
+    Parameters
+    ----------
+    width, height:
+        Size of the Pygame window in pixels.
+    scale:
+        Scale applied to positions stored in :class:`TransformNode`s.
+    """
+
+    def __init__(self, width: int = 640, height: int = 480, scale: float = 5.0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        # Allow running in headless environments for tests
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+        pygame.init()
+        self.screen = pygame.display.set_mode((width, height))
+        pygame.display.set_caption(self.name)
+        self.font = pygame.font.Font(None, 24)
+        self.scale = scale
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _root(self) -> SystemNode:
+        node: SystemNode = self
+        while node.parent is not None:
+            node = node.parent  # type: ignore[assignment]
+        return node
+
+    def _walk(self, node) -> Iterator[SystemNode]:
+        yield node
+        for child in node.children:
+            yield from self._walk(child)
+
+    # ------------------------------------------------------------------
+    # Simulation API
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:  # noqa: D401 - inherit docstring
+        """Update the window and render state."""
+        # Handle Pygame events (close window etc.)
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                pygame.quit()
+                return
+
+        self.screen.fill((30, 30, 30))
+
+        lines: List[str] = []
+        for node in self._walk(self._root()):
+            if isinstance(node, InventoryNode):
+                lines.append(f"{node.name} inv: {node.items}")
+            if isinstance(node, NeedNode):
+                lines.append(f"{node.name}: {node.value:.1f}/{node.threshold}")
+            if isinstance(node, TransformNode):
+                x, y = node.position
+                pygame.draw.circle(
+                    self.screen,
+                    (0, 200, 0),
+                    (int(x * self.scale), int(y * self.scale)),
+                    5,
+                )
+
+        for i, text in enumerate(lines):
+            surf = self.font.render(text, True, (220, 220, 220))
+            self.screen.blit(surf, (10, 10 + i * 20))
+
+        pygame.display.flip()
+        super().update(dt)
+
+
+register_node_type("PygameViewerSystem", PygameViewerSystem)

--- a/tests/test_pygame_viewer.py
+++ b/tests/test_pygame_viewer.py
@@ -1,0 +1,19 @@
+import os
+
+import pytest
+
+from nodes.world import WorldNode
+from nodes.inventory import InventoryNode
+
+
+def test_pygame_viewer_runs():
+    pygame = pytest.importorskip("pygame")
+    from systems.pygame_viewer import PygameViewerSystem
+
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    world = WorldNode(name="world")
+    InventoryNode(name="inv", items={"wheat": 1}, parent=world)
+    viewer = PygameViewerSystem(parent=world, width=120, height=80)
+    world.update(0)
+    assert viewer.screen.get_size() == (120, 80)
+    pygame.quit()


### PR DESCRIPTION
## Summary
- add PygameViewerSystem to render inventories, needs and positions in a window
- integrate viewer into example configuration and depend on pygame
- document feature in project checklist

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c6913e388330b2653fc800105211