### PR TITLE
Add farm simulation with daily routines for farmers

### DIFF
--- a/VISUALISATION_ENV.md
+++ b/VISUALISATION_ENV.md
@@ -10,16 +10,25 @@ Ce guide explique comment préparer un environnement Python pour exécuter la si
 
 ## 2. Installation automatique
 
-Executez les commandes suivantes à la racine du projet pour créer un environnement virtuel et installer les dépendances.
+Exécutez les commandes suivantes à la racine du projet pour créer un environnement
+virtuel et installer les dépendances. La commande d'activation dépend de votre
+plateforme :
 
 ```bash
-python -m venv .venv && \
-  source .venv/Scripts/activate && \
-  pip install --upgrade pip && \
-  pip install -r requirements.txt
+python -m venv .venv
+
+# Sous Linux/macOS
+source .venv/bin/activate
+# Sous Windows PowerShell
+.\.venv\Scripts\Activate.ps1
+# Sous Windows CMD
+.\.venv\Scripts\activate.bat
+
+pip install --upgrade pip
+pip install -r requirements.txt
 ```
 
-Ces commandes peuvent être copiées/collées telles quelles : tout s'enchaîne automatiquement.
+Ces commandes peuvent être copiées/collées successivement dans le terminal.
 
 ## 3. Vérification des dépendances
 
@@ -31,23 +40,15 @@ pytest
 
 ## 4. Lancer une visualisation d'exemple
 
-Pour voir une simulation simple s'afficher dans une fenêtre Pygame :
+Pour voir la ferme s'animer dans une fenêtre Pygame :
 
 ```bash
 # Dans le terminal où l'environnement virtuel est activé
-unset SDL_VIDEODRIVER  # laisser Pygame gérer l'affichage
-python - <<'PY'
-from core.loader import load_simulation_from_file
-from systems.pygame_viewer import PygameViewerSystem
-
-world = load_simulation_from_file("example_farm.json")
-viewer = PygameViewerSystem(parent=world)
-for _ in range(1000):
-    world.update(0.016)
-PY
+unset SDL_VIDEODRIVER  # seulement si vous l'aviez défini précédemment
+python run_farm.py
 ```
 
-Une fenêtre Pygame apparaît avec un affichage minimal des entités simulées.
+Une fenêtre Pygame apparaît avec trois fermiers qui vivent leur journée.
 
 ## 5. Pour aller plus loin
 

--- a/example_farm.json
+++ b/example_farm.json
@@ -7,23 +7,84 @@
         "type": "FarmNode",
         "id": "farm",
         "children": [
-          {"type": "InventoryNode", "id": "farm_inventory", "config": {"items": {}}},
-          {"type": "ResourceProducerNode", "config": {"resource": "wheat", "rate_per_tick": 1}, "id": "producer"}
+          {"type": "InventoryNode", "id": "farm_inventory", "config": {"items": {}}}
         ]
       },
       {
         "type": "CharacterNode",
-        "id": "farmer",
+        "id": "farmer1",
         "children": [
-          {"type": "NeedNode", "config": {"name": "hunger", "threshold": 3, "increase_rate": 2}},
+          {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {}}
+          {"type": "ResourceProducerNode", "config": {"resource": "wheat", "rate_per_tick": 1, "active": false}},
+          {
+            "type": "AIBehaviorNode",
+            "config": {
+              "home": [20, 20],
+              "work_position": [40, 40],
+              "wander_range": 1.5,
+              "routine": [
+                {"start": 6, "end": 8, "action": "wander"},
+                {"start": 8, "end": 16, "action": "work"},
+                {"start": 16, "end": 20, "action": "wander"},
+                {"start": 20, "end": 24, "action": "sleep"},
+                {"start": 0, "end": 6, "action": "sleep"}
+              ]
+            }
+          }
         ]
       },
-      {"type": "TimeSystem", "id": "time"},
+      {
+        "type": "CharacterNode",
+        "id": "farmer2",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [50, 20]}},
+          {"type": "InventoryNode", "config": {"items": {}}},
+          {"type": "ResourceProducerNode", "config": {"resource": "wheat", "rate_per_tick": 1, "active": false}},
+          {
+            "type": "AIBehaviorNode",
+            "config": {
+              "home": [50, 20],
+              "work_position": [60, 60],
+              "wander_range": 1.5,
+              "routine": [
+                {"start": 6, "end": 8, "action": "wander"},
+                {"start": 8, "end": 16, "action": "work"},
+                {"start": 16, "end": 20, "action": "wander"},
+                {"start": 20, "end": 24, "action": "sleep"},
+                {"start": 0, "end": 6, "action": "sleep"}
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "type": "CharacterNode",
+        "id": "farmer3",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [80, 20]}},
+          {"type": "InventoryNode", "config": {"items": {}}},
+          {"type": "ResourceProducerNode", "config": {"resource": "wheat", "rate_per_tick": 1, "active": false}},
+          {
+            "type": "AIBehaviorNode",
+            "config": {
+              "home": [80, 20],
+              "work_position": [20, 60],
+              "wander_range": 1.5,
+              "routine": [
+                {"start": 6, "end": 8, "action": "wander"},
+                {"start": 8, "end": 16, "action": "work"},
+                {"start": 16, "end": 20, "action": "wander"},
+                {"start": 20, "end": 24, "action": "sleep"},
+                {"start": 0, "end": 6, "action": "sleep"}
+              ]
+            }
+          }
+        ]
+      },
+      {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 1.0, "phase_length": 12}},
       {"type": "EconomySystem", "id": "economy"},
-      {"type": "LoggingSystem", "id": "logger"},
-      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 400, "height": 300}}
+      {"type": "LoggingSystem", "id": "logger"}
     ]
   }
 }

--- a/nodes/ai_behavior.py
+++ b/nodes/ai_behavior.py
@@ -1,25 +1,90 @@
-"""Simple AI behaviour reacting to needs."""
+"""Simple AI behaviour for farmers with daily routines."""
 from __future__ import annotations
 
-from typing import Optional
+import random
+from typing import Dict, List, Optional
 
 from core.simnode import SimNode
 from core.plugins import register_node_type
 from .inventory import InventoryNode
 from .need import NeedNode
+from .resource_producer import ResourceProducerNode
+from .transform import TransformNode
 
 
 class AIBehaviorNode(SimNode):
-    """Very small behaviour for a farmer.
+    """Small behaviour node implementing a daily routine.
 
-    When hunger reaches its threshold, the AI takes wheat from a target
-    inventory and satisfies the hunger need.
+    Parameters
+    ----------
+    routine:
+        List of dictionaries of the form ``{"start": int, "end": int,
+        "action": str}`` describing the action to perform for each hour
+        interval. Actions supported are ``"work"``, ``"wander"`` and
+        ``"sleep"``.
+    home:
+        Position ``[x, y]`` where the character sleeps at night.
+    work_position:
+        Position ``[x, y]`` representing the working area.
+    wander_range:
+        Maximum distance in pixels travelled in a random direction when
+        wandering.
+    target_inventory:
+        Optional inventory from which the farmer can eat when hungry.
     """
 
-    def __init__(self, target_inventory: Optional[InventoryNode] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        routine: Optional[List[Dict[str, int]]] = None,
+        home: Optional[List[float]] = None,
+        work_position: Optional[List[float]] = None,
+        wander_range: float = 1.0,
+        target_inventory: Optional[InventoryNode] = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.target_inventory = target_inventory
+        self.routine = routine or []
+        self.home = home or [0.0, 0.0]
+        self.work_position = work_position or self.home
+        self.wander_range = wander_range
         self.on_event("need_threshold_reached", self._on_need)
+        self.on_event("tick", self._on_tick)
+        self._state: Optional[str] = None
+
+    def _action_for_hour(self, hour: int) -> Optional[str]:
+        for entry in self.routine:
+            if entry["start"] <= hour < entry["end"]:
+                return entry["action"]
+        return None
+
+    def _on_tick(self, emitter: SimNode, event_name: str, payload) -> None:
+        hour = payload.get("tick", 0)
+        action = self._action_for_hour(hour)
+        self._apply_action(action)
+
+    def _apply_action(self, action: Optional[str]) -> None:
+        transform = self._find_transform()
+        producer = self._find_producer()
+        if action == "work":
+            if transform:
+                transform.position = list(self.work_position)
+            if producer:
+                producer.active = True
+        elif action == "wander":
+            if producer:
+                producer.active = False
+            if transform:
+                transform.position[0] += random.uniform(-self.wander_range, self.wander_range)
+                transform.position[1] += random.uniform(-self.wander_range, self.wander_range)
+        elif action == "sleep":
+            if producer:
+                producer.active = False
+            if transform:
+                transform.position = list(self.home)
+        else:
+            if producer:
+                producer.active = False
 
     def _on_need(self, emitter: SimNode, event_name: str, payload) -> None:
         if payload.get("need") != "hunger":
@@ -35,6 +100,18 @@ class AIBehaviorNode(SimNode):
     def _find_inventory(self) -> Optional[InventoryNode]:
         for child in self.parent.children:
             if isinstance(child, InventoryNode):
+                return child
+        return None
+
+    def _find_transform(self) -> Optional[TransformNode]:
+        for child in self.parent.children:
+            if isinstance(child, TransformNode):
+                return child
+        return None
+
+    def _find_producer(self) -> Optional[ResourceProducerNode]:
+        for child in self.parent.children:
+            if isinstance(child, ResourceProducerNode):
                 return child
         return None
 

--- a/nodes/resource_producer.py
+++ b/nodes/resource_producer.py
@@ -17,6 +17,7 @@ class ResourceProducerNode(SimNode):
         rate_per_tick: int,
         inputs: Optional[Dict[str, int]] = None,
         output_inventory: Optional[InventoryNode] = None,
+        active: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -24,10 +25,15 @@ class ResourceProducerNode(SimNode):
         self.rate_per_tick = rate_per_tick
         self.inputs = inputs or {}
         self.output_inventory = output_inventory
+        self.active = active
 
     def update(self, dt: float) -> None:
+        if not self.active:
+            super().update(dt)
+            return
         inv = self.output_inventory or self._find_inventory()
         if inv is None:
+            super().update(dt)
             return
         if all(inv.items.get(name, 0) >= qty for name, qty in self.inputs.items()):
             for name, qty in self.inputs.items():

--- a/run_farm.py
+++ b/run_farm.py
@@ -1,12 +1,33 @@
 from core.loader import load_simulation_from_file
+from core.plugins import load_plugins
 from systems.pygame_viewer import PygameViewerSystem
 
-# Charge la simulation depuis un fichier JSON/YAML
+# Enregistre les types de nœuds disponibles
+load_plugins(
+    [
+        "nodes.world",
+        "nodes.farm",
+        "nodes.inventory",
+        "nodes.resource_producer",
+        "nodes.character",
+        "nodes.need",
+        "nodes.ai_behavior",
+        "nodes.transform",
+        "systems.time",
+        "systems.economy",
+        "systems.logger",
+    ]
+)
+
+# Charge la simulation depuis un fichier JSON
 world = load_simulation_from_file("example_farm.json")
 
-# Ajoute le système d'affichage (ex: Pygame)
+# Ajoute le système d'affichage
 viewer = PygameViewerSystem(parent=world)
 
 # Boucle de mise à jour
-while True:
-    world.update(0.016)
+try:
+    while True:
+        world.update(0.016)
+except KeyboardInterrupt:
+    pass

--- a/systems/time.py
+++ b/systems/time.py
@@ -6,22 +6,38 @@ from core.plugins import register_node_type
 
 
 class TimeSystem(SystemNode):
-    """Emit a `tick` event every update and handle day/night phases."""
+    """Emit ``tick`` events and manage day/night phases.
 
-    def __init__(self, tick_duration: float = 1.0, phase_length: int = 10, **kwargs) -> None:
+    The system now models a 24h cycle.  Each call to :meth:`update` accumulates
+    ``dt`` until ``tick_duration`` is reached, at which point the current hour is
+    incremented and a ``tick`` event is emitted with the hour of the day.  After
+    ``phase_length`` hours the day/night phase toggles and a ``phase_changed``
+    event is emitted.
+    """
+
+    def __init__(self, tick_duration: float = 1.0, phase_length: int = 12, **kwargs) -> None:
         super().__init__(**kwargs)
         self.tick_duration = tick_duration
         self.phase_length = phase_length
         self.current_tick = 0
         self.phase = 0
+        self.day = 0
+        self._accum = 0.0
 
     def update(self, dt: float) -> None:
-        self.current_tick += 1
-        self.emit("tick", {"tick": self.current_tick}, direction="down")
-        new_phase = (self.current_tick // self.phase_length) % 2
-        if new_phase != self.phase:
-            self.phase = new_phase
-            self.emit("phase_changed", {"phase": self.phase}, direction="down")
+        self._accum += dt
+        while self._accum >= self.tick_duration:
+            self._accum -= self.tick_duration
+            self.current_tick += 1
+            hour = self.current_tick % (2 * self.phase_length)
+            if hour == 0 and self.current_tick > 0:
+                self.day += 1
+            self.emit("tick", {"tick": hour, "day": self.day}, direction="down")
+            new_phase = (hour // self.phase_length) % 2
+            if new_phase != self.phase:
+                self.phase = new_phase
+                self.emit("phase_changed", {"phase": self.phase}, direction="down")
+        super().update(dt)
 
 
 register_node_type("TimeSystem", TimeSystem)


### PR DESCRIPTION
## Summary
- simulate a full day/night cycle
- add farmer AI with daily routines and resource production
- document visualization setup for Windows and run script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893d0fe9e0c8330aa51c219bde1f83f