### PR TITLE
Fix Pygame window and add accelerated day cycle

### DIFF
--- a/example_farm.json
+++ b/example_farm.json
@@ -7,6 +7,7 @@
         "type": "FarmNode",
         "id": "farm",
         "children": [
+          {"type": "TransformNode", "config": {"position": [50, 50]}},
           {"type": "InventoryNode", "id": "farm_inventory", "config": {"items": {}}},
           {"type": "ResourceProducerNode", "config": {"resource": "wheat", "rate_per_tick": 1}, "id": "producer"}
         ]
@@ -15,7 +16,8 @@
         "type": "CharacterNode",
         "id": "farmer",
         "children": [
-          {"type": "NeedNode", "config": {"name": "hunger", "threshold": 3, "increase_rate": 2}},
+          {"type": "TransformNode", "config": {"position": [20, 20]}},
+          {"type": "NeedNode", "config": {"name": "hunger", "threshold": 1000, "increase_rate": 0.035}},
           {"type": "InventoryNode", "config": {"items": {}}},
           {"type": "AIBehaviorNode", "config": {}}
         ]

--- a/nodes/ai_behavior.py
+++ b/nodes/ai_behavior.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 from typing import Optional
+import random
 
 from core.simnode import SimNode
 from core.plugins import register_node_type
 from .inventory import InventoryNode
 from .need import NeedNode
+from .transform import TransformNode
 
 
 class AIBehaviorNode(SimNode):
@@ -16,10 +18,18 @@ class AIBehaviorNode(SimNode):
     inventory and satisfies the hunger need.
     """
 
-    def __init__(self, target_inventory: Optional[InventoryNode] = None, **kwargs) -> None:
+    def __init__(self, target_inventory: Optional[InventoryNode] = None, speed: float = 10.0, **kwargs) -> None:
         super().__init__(**kwargs)
         self.target_inventory = target_inventory
+        self.speed = speed
         self.on_event("need_threshold_reached", self._on_need)
+
+    def update(self, dt: float) -> None:
+        transform = self._find_transform()
+        if transform is not None:
+            transform.position[0] += random.uniform(-1, 1) * self.speed * dt
+            transform.position[1] += random.uniform(-1, 1) * self.speed * dt
+        super().update(dt)
 
     def _on_need(self, emitter: SimNode, event_name: str, payload) -> None:
         if payload.get("need") != "hunger":
@@ -41,6 +51,12 @@ class AIBehaviorNode(SimNode):
     def _find_need(self, name: str) -> Optional[NeedNode]:
         for child in self.parent.children:
             if isinstance(child, NeedNode) and child.need_name == name:
+                return child
+        return None
+
+    def _find_transform(self) -> Optional[TransformNode]:
+        for child in self.parent.children:
+            if isinstance(child, TransformNode):
                 return child
         return None
 

--- a/run_farm.py
+++ b/run_farm.py
@@ -1,12 +1,73 @@
+"""Run the farm simulation with a visual Pygame window."""
+
+from __future__ import annotations
+
+import pygame
+
 from core.loader import load_simulation_from_file
+from core.plugins import load_plugins
+from nodes.ai_behavior import AIBehaviorNode
+from nodes.inventory import InventoryNode
+from nodes.resource_producer import ResourceProducerNode
 from systems.pygame_viewer import PygameViewerSystem
+
+
+# Charge tous les plugins nécessaires pour la simulation
+load_plugins(
+    [
+        "nodes.world",
+        "nodes.farm",
+        "nodes.inventory",
+        "nodes.resource_producer",
+        "nodes.character",
+        "nodes.need",
+        "nodes.ai_behavior",
+        "nodes.transform",
+        "systems.time",
+        "systems.economy",
+        "systems.logger",
+        "systems.pygame_viewer",
+    ]
+)
+
+
+def _find(node, name):
+    if node.name == name:
+        return node
+    for child in node.children:
+        found = _find(child, name)
+        if found:
+            return found
+    return None
+
 
 # Charge la simulation depuis un fichier JSON/YAML
 world = load_simulation_from_file("example_farm.json")
 
-# Ajoute le système d'affichage (ex: Pygame)
-viewer = PygameViewerSystem(parent=world)
+# Relie les composants qui doivent coopérer
+farm_inventory = _find(world, "farm_inventory")
+producer = _find(world, "producer")
+if isinstance(producer, ResourceProducerNode) and isinstance(farm_inventory, InventoryNode):
+    producer.output_inventory = farm_inventory
 
-# Boucle de mise à jour
-while True:
-    world.update(0.016)
+farmer = _find(world, "farmer")
+if farmer:
+    ai = next((c for c in farmer.children if isinstance(c, AIBehaviorNode)), None)
+    if ai and isinstance(farm_inventory, InventoryNode):
+        ai.target_inventory = farm_inventory
+
+# Ajoute un système d'affichage si absent
+if not any(isinstance(c, PygameViewerSystem) for c in world.children):
+    PygameViewerSystem(parent=world)
+
+
+FPS = 24
+TIME_SCALE = 86400 / (3 * 60)  # 1 journée simulée = 3 minutes réelles
+
+clock = pygame.time.Clock()
+
+while pygame.get_init():
+    dt = clock.tick(FPS) / 1000.0
+    world.update(dt * TIME_SCALE)
+
+pygame.quit()

--- a/systems/time.py
+++ b/systems/time.py
@@ -6,7 +6,7 @@ from core.plugins import register_node_type
 
 
 class TimeSystem(SystemNode):
-    """Emit a `tick` event every update and handle day/night phases."""
+    """Emit a `tick` event based on elapsed time and track the day cycle."""
 
     def __init__(self, tick_duration: float = 1.0, phase_length: int = 10, **kwargs) -> None:
         super().__init__(**kwargs)
@@ -14,14 +14,21 @@ class TimeSystem(SystemNode):
         self.phase_length = phase_length
         self.current_tick = 0
         self.phase = 0
+        self.current_time = 0.0  # seconds since start of day
+        self._accumulator = 0.0
+        self.day_length = 24 * 3600.0
 
     def update(self, dt: float) -> None:
-        self.current_tick += 1
-        self.emit("tick", {"tick": self.current_tick}, direction="down")
-        new_phase = (self.current_tick // self.phase_length) % 2
-        if new_phase != self.phase:
-            self.phase = new_phase
-            self.emit("phase_changed", {"phase": self.phase}, direction="down")
+        self._accumulator += dt
+        while self._accumulator >= self.tick_duration:
+            self._accumulator -= self.tick_duration
+            self.current_tick += 1
+            self.current_time = (self.current_time + self.tick_duration) % self.day_length
+            self.emit("tick", {"tick": self.current_tick}, direction="down")
+            new_phase = (self.current_tick // self.phase_length) % 2
+            if new_phase != self.phase:
+                self.phase = new_phase
+                self.emit("phase_changed", {"phase": self.phase}, direction="down")
 
 
 register_node_type("TimeSystem", TimeSystem)


### PR DESCRIPTION
## Summary
- ensure Pygame opens a real window and show current time
- run simulation at fixed 24 FPS with a day lasting three minutes
- add basic movement and transforms so characters perform visible actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d4b849c0833098877dee004b3018