### PR TITLE
Fix NeedNode name collision and document simulation run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ An example configuration file `example_farm.json` demonstrates a minimal world s
 
 The engine includes a `LoggingSystem` that prints selected events, offering a basic way to observe simulations from the console.
 
+## Running the simulation
+
+After installing the dependencies, launch the Pygame-powered example farm:
+
+```
+python run_farm.py
+```
+
 ## Development
 
 * Python 3.9+
@@ -17,3 +25,7 @@ The engine includes a `LoggingSystem` that prints selected events, offering a ba
 ## License
 
 MIT
+
+## TODO
+
+- Implement seed-based reproducibility for deterministic simulations.

--- a/example_farm.json
+++ b/example_farm.json
@@ -17,7 +17,7 @@
         "id": "farmer",
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 20]}},
-          {"type": "NeedNode", "config": {"name": "hunger", "threshold": 1000, "increase_rate": 0.035}},
+          {"type": "NeedNode", "config": {"need_name": "hunger", "threshold": 1000, "increase_rate": 0.035}},
           {"type": "InventoryNode", "config": {"items": {}}},
           {"type": "AIBehaviorNode", "config": {}}
         ]

--- a/nodes/need.py
+++ b/nodes/need.py
@@ -12,7 +12,7 @@ class NeedNode(SimNode):
 
     def __init__(
         self,
-        name: str,
+        need_name: str,
         threshold: float,
         increase_rate: float,
         decrease_rate: float = 0.0,
@@ -20,7 +20,7 @@ class NeedNode(SimNode):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        self.need_name = name
+        self.need_name = need_name
         self.threshold = threshold
         self.increase_rate = increase_rate
         self.decrease_rate = decrease_rate

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -69,7 +69,7 @@ class PygameViewerSystem(SystemNode):
             if isinstance(node, InventoryNode):
                 lines.append(f"{node.name} inv: {node.items}")
             if isinstance(node, NeedNode):
-                lines.append(f"{node.name}: {node.value:.1f}/{node.threshold}")
+                lines.append(f"{node.need_name}: {node.value:.1f}/{node.threshold}")
             if isinstance(node, TransformNode):
                 x, y = node.position
                 pygame.draw.circle(

--- a/tests/test_ai_behavior.py
+++ b/tests/test_ai_behavior.py
@@ -7,7 +7,7 @@ from nodes.character import CharacterNode
 def test_ai_eats_when_hungry():
     farm_inv = InventoryNode(name="farm", items={"wheat": 5})
     char = CharacterNode(name="farmer")
-    hunger = NeedNode(name="hunger", threshold=5, increase_rate=5, parent=char)
+    hunger = NeedNode(need_name="hunger", threshold=5, increase_rate=5, parent=char)
     personal_inv = InventoryNode(name="personal", items={}, parent=char)
     ai = AIBehaviorNode(parent=char, target_inventory=farm_inv)
     hunger.update(1)  # value =5 -> threshold

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ def test_farm_simulation_cycle():
     producer = ResourceProducerNode(resource="wheat", rate_per_tick=1, output_inventory=farm_inv, parent=farm)
 
     char = CharacterNode(name="farmer", parent=world)
-    hunger = NeedNode(name="hunger", threshold=3, increase_rate=2, parent=char)
+    hunger = NeedNode(need_name="hunger", threshold=3, increase_rate=2, parent=char)
     personal_inv = InventoryNode(name="personal", items={}, parent=char)
     ai = AIBehaviorNode(parent=char, target_inventory=farm_inv)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -9,7 +9,7 @@ from systems.logger import LoggingSystem
 def test_logging_system_records_events(caplog):
     world = WorldNode(name="world")
     char = CharacterNode(name="char", parent=world)
-    need = NeedNode(name="hunger", threshold=1, increase_rate=2, parent=char)
+    need = NeedNode(need_name="hunger", threshold=1, increase_rate=2, parent=char)
     logger_sys = LoggingSystem(parent=world, events=["need_threshold_reached"])
     with caplog.at_level(logging.INFO, logger=logger_sys.logger.name):
         world.update(1)

--- a/tests/test_need.py
+++ b/tests/test_need.py
@@ -7,7 +7,7 @@ def test_need_threshold_and_satisfy():
     def handler(emitter, event, payload):
         events.append(event)
 
-    need = NeedNode(name="hunger", threshold=10, increase_rate=5)
+    need = NeedNode(need_name="hunger", threshold=10, increase_rate=5)
     need.on_event("need_threshold_reached", handler)
     need.update(1)  # value=5
     assert events == []


### PR DESCRIPTION
## Summary
- Rename NeedNode's `name` parameter to `need_name` to avoid conflicting with SimNode's name
- Display NeedNode's `need_name` in Pygame viewer and update example configuration
- Add README instructions for running the simulation and note TODO for seed-based reproducibility

## Testing
- `python run_farm.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893d7a7bd148330a29170313b380a51