### PR TITLE
Add worker schedule and houses to farm simulation

### DIFF
--- a/example_farm.json
+++ b/example_farm.json
@@ -4,28 +4,78 @@
     "config": {"width": 100, "height": 100},
     "children": [
       {
-        "type": "FarmNode",
-        "id": "farm",
+        "type": "HouseNode",
+        "id": "house1",
         "children": [
-          {"type": "TransformNode", "config": {"position": [50, 50]}},
-          {"type": "InventoryNode", "id": "farm_inventory", "config": {"items": {}}},
-          {"type": "ResourceProducerNode", "config": {"resource": "wheat", "rate_per_tick": 1}, "id": "producer"}
+          {"type": "TransformNode", "config": {"position": [10, 10]}},
+          {"type": "InventoryNode", "id": "house1_inventory", "config": {"items": {}}}
+        ]
+      },
+      {
+        "type": "HouseNode",
+        "id": "house2",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [20, 80]}},
+          {"type": "InventoryNode", "id": "house2_inventory", "config": {"items": {}}}
+        ]
+      },
+      {
+        "type": "HouseNode",
+        "id": "house3",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [80, 20]}},
+          {"type": "InventoryNode", "id": "house3_inventory", "config": {"items": {}}}
+        ]
+      },
+      {
+        "type": "FarmNode",
+        "id": "farm1",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [60, 60]}},
+          {"type": "InventoryNode", "id": "farm1_inventory", "config": {"items": {}}},
+          {"type": "ResourceProducerNode", "id": "producer1", "config": {"resource": "wheat", "rate_per_tick": 1}}
+        ]
+      },
+      {
+        "type": "FarmNode",
+        "id": "farm2",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [80, 80]}},
+          {"type": "InventoryNode", "id": "farm2_inventory", "config": {"items": {}}},
+          {"type": "ResourceProducerNode", "id": "producer2", "config": {"resource": "wheat", "rate_per_tick": 1}}
         ]
       },
       {
         "type": "CharacterNode",
-        "id": "farmer",
+        "id": "worker1",
         "children": [
-          {"type": "TransformNode", "config": {"position": [20, 20]}},
-          {"type": "NeedNode", "config": {"need_name": "hunger", "threshold": 1000, "increase_rate": 0.035}},
-          {"type": "InventoryNode", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {}}
+          {"type": "TransformNode", "config": {"position": [10, 10]}},
+          {"type": "InventoryNode", "id": "worker1_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm1", "home_inventory": "house1_inventory", "lunch_position": [50, 50], "speed": 20.0, "idle_chance": 0.2}}
         ]
       },
-      {"type": "TimeSystem", "id": "time"},
+      {
+        "type": "CharacterNode",
+        "id": "worker2",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [20, 80]}},
+          {"type": "InventoryNode", "id": "worker2_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm2", "home_inventory": "house2_inventory", "lunch_position": [50, 50], "speed": 20.0, "idle_chance": 0.2}}
+        ]
+      },
+      {
+        "type": "CharacterNode",
+        "id": "worker3",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [80, 20]}},
+          {"type": "InventoryNode", "id": "worker3_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm1", "home_inventory": "house3_inventory", "lunch_position": [50, 50], "speed": 20.0, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60}},
       {"type": "EconomySystem", "id": "economy"},
       {"type": "LoggingSystem", "id": "logger"},
-      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 400, "height": 300}}
+      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 800, "height": 600, "scale": 5}}
     ]
   }
 }

--- a/nodes/house.py
+++ b/nodes/house.py
@@ -1,0 +1,15 @@
+"""Simple house node."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class HouseNode(SimNode):
+    """Represents a house where characters live and store resources."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+
+register_node_type("HouseNode", HouseNode)

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -11,6 +11,9 @@ from core.plugins import register_node_type
 from nodes.inventory import InventoryNode
 from nodes.need import NeedNode
 from nodes.transform import TransformNode
+from nodes.character import CharacterNode
+from nodes.farm import FarmNode
+from nodes.house import HouseNode
 from systems.time import TimeSystem
 
 
@@ -71,13 +74,17 @@ class PygameViewerSystem(SystemNode):
             if isinstance(node, NeedNode):
                 lines.append(f"{node.need_name}: {node.value:.1f}/{node.threshold}")
             if isinstance(node, TransformNode):
+                parent = node.parent
                 x, y = node.position
-                pygame.draw.circle(
-                    self.screen,
-                    (0, 200, 0),
-                    (int(x * self.scale), int(y * self.scale)),
-                    5,
-                )
+                pos = (int(x * self.scale), int(y * self.scale))
+                if isinstance(parent, CharacterNode):
+                    pygame.draw.circle(self.screen, (0, 200, 0), pos, 5)
+                elif isinstance(parent, FarmNode):
+                    pygame.draw.rect(self.screen, (150, 100, 50), (*pos, 20, 20))
+                elif isinstance(parent, HouseNode):
+                    pygame.draw.rect(self.screen, (50, 100, 200), (*pos, 20, 20))
+                else:
+                    pygame.draw.circle(self.screen, (200, 200, 200), pos, 3)
             if isinstance(node, TimeSystem):
                 time_sys = node
 


### PR DESCRIPTION
## Summary
- add an AI schedule for workers to commute between home, farms and lunch, earning wages and storing money
- show houses and farms in Pygame viewer and enlarge example world with three houses, two farms and three workers
- support simple HouseNode and auto-link resource producers

## Testing
- `pytest`
- `python run_farm.py`

------
https://chatgpt.com/codex/tasks/task_e_6893dc20575c8330bfb5671cd3e31c44