### PR TITLE
Add schedule and movement animation

### DIFF
--- a/example_farm.json
+++ b/example_farm.json
@@ -51,7 +51,7 @@
         "children": [
           {"type": "TransformNode", "config": {"position": [10, 10]}},
           {"type": "InventoryNode", "id": "worker1_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm1", "home_inventory": "house1_inventory", "lunch_position": [50, 50], "speed": 20.0, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm1", "home_inventory": "house1_inventory", "lunch_position": [50, 50], "speed": 0.05, "idle_chance": 0.2}}
         ]
       },
       {
@@ -60,7 +60,7 @@
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 80]}},
           {"type": "InventoryNode", "id": "worker2_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm2", "home_inventory": "house2_inventory", "lunch_position": [50, 50], "speed": 20.0, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm2", "home_inventory": "house2_inventory", "lunch_position": [50, 50], "speed": 0.05, "idle_chance": 0.2}}
         ]
       },
       {
@@ -69,7 +69,7 @@
         "children": [
           {"type": "TransformNode", "config": {"position": [80, 20]}},
           {"type": "InventoryNode", "id": "worker3_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm1", "home_inventory": "house3_inventory", "lunch_position": [50, 50], "speed": 20.0, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm1", "home_inventory": "house3_inventory", "lunch_position": [50, 50], "speed": 0.05, "idle_chance": 0.2}}
         ]
       },
       {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60}},

--- a/run_farm.py
+++ b/run_farm.py
@@ -64,7 +64,7 @@ if not any(isinstance(c, PygameViewerSystem) for c in world.children):
 
 
 FPS = 24
-TIME_SCALE = 86400 / (3 * 60)  # 1 journée simulée = 3 minutes réelles
+TIME_SCALE = 86400 / 60  # 1 journée simulée = 1 minute réelle
 
 clock = pygame.time.Clock()
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import random
+
+from core.simnode import SimNode
+from nodes.world import WorldNode
+from nodes.character import CharacterNode
+from nodes.inventory import InventoryNode
+from nodes.transform import TransformNode
+from nodes.ai_behavior import AIBehaviorNode
+from systems.time import TimeSystem
+
+
+def _create_ai():
+    world = WorldNode(name="world")
+    home = SimNode(name="home", parent=world)
+    TransformNode(position=[0.0, 0.0], parent=home)
+    work = SimNode(name="work", parent=world)
+    TransformNode(position=[10.0, 0.0], parent=work)
+    char = CharacterNode(name="char", parent=world)
+    trans = TransformNode(position=[0.0, 0.0], parent=char)
+    InventoryNode(name="inv", items={}, parent=char)
+    ai = AIBehaviorNode(parent=char, home="home", work="work")
+    time = TimeSystem(parent=world)
+    ai._resolve_references()
+    return ai, time, trans
+
+
+def test_schedule_and_sleeping():
+    ai, time, _ = _create_ai()
+
+    time.current_time = 5 * 3600
+    target = ai._determine_target()
+    assert ai._sleeping is True
+    assert target == [0.0, 0.0]
+
+    time.current_time = 9 * 3600
+    target = ai._determine_target()
+    assert ai._sleeping is False
+    assert target == [10.0, 0.0]
+
+    time.current_time = 23 * 3600
+    target = ai._determine_target()
+    assert ai._sleeping is True
+    assert target == [0.0, 0.0]
+
+
+def test_idle_jitter():
+    random.seed(0)
+    ai, time, trans = _create_ai()
+
+    time.current_time = 7 * 3600
+    ai.update(1.0)
+    assert ai._sleeping is False
+    assert trans.position != [0.0, 0.0]
+    assert abs(trans.position[0]) <= 0.5
+    assert abs(trans.position[1]) <= 0.5
+
+    trans.position = [0.0, 0.0]
+    time.current_time = 23 * 3600
+    ai.update(1.0)
+    assert trans.position == [0.0, 0.0]


### PR DESCRIPTION
## Summary
- add sleeping schedule and idle jitter to AIBehaviorNode
- run 24h of simulation in one minute
- include tests for schedule and idle jitter

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893dfcb1a7c8330a2b4aed738a8073a