### PR TITLE
docs: add roadmap and align root docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,4 @@ python run_farm.py
 
 MIT
 
-## TODO
-
-- Implement seed-based reproducibility for deterministic simulations.
+See [TODO.md](TODO.md) for the full roadmap and upcoming enhancements.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,78 @@
+# TODO Roadmap
+
+This document extends the checklist in [project_spec.md](project_spec.md)
+with ambitious, long‑term tasks. Items are grouped by theme and can be
+checked off as the project evolves.
+
+## Core Engine Enhancements
+
+- [ ] Implement seed-based reproducibility for deterministic simulations.
+- [ ] Expand the event bus with priority levels and asynchronous
+      dispatching.
+- [ ] Support serialising and reloading full world state for snapshots
+      and debugging.
+- [ ] Provide a scheduling system to update nodes at different rates.
+- [ ] Optimise the update loop for large simulations (profiling,
+      micro‑benchmarks).
+
+## Tools for Creation
+
+- [ ] Command-line tool to scaffold new node or system plugins from
+      templates.
+- [ ] Schema validation utility for configuration files (YAML/JSON).
+- [ ] Graphical node editor allowing drag-and-drop composition and
+      export to declarative configs.
+  - [ ] Basic UI to add/remove nodes and edit properties.
+  - [ ] Live simulation preview panel.
+  - [ ] Plugin manager to enable/disable community packages.
+- [ ] Repository or marketplace for sharing community-created nodes and
+      scenarios.
+
+## Visualization and Rendering
+
+- [ ] Extend the Pygame viewer with camera controls, zoom and
+      overlays for inventories, needs and events.
+- [ ] Headless rendering mode that streams frames or state for remote
+      dashboards.
+- [ ] Web-based viewer (WebGL/Canvas) to observe simulations in the
+      browser.
+- [ ] Optional 3D rendering backend (e.g., Panda3D) with automatic
+      asset mapping from node properties.
+- [ ] Recording and replay tool to capture simulation sessions.
+
+## Advanced Simulation Mechanics
+
+- [ ] Weather and seasonal systems influencing production rates and
+      character behaviour.
+- [ ] Animal nodes with needs, reproduction and resource generation.
+- [ ] Dynamic economy with fluctuating prices and market events.
+- [ ] Quest or objective system using dedicated `QuestNode` types.
+- [ ] Combat mechanics including equipment, damage and defence systems.
+- [ ] Behaviour tree library for complex AI decision making.
+- [ ] Modular skill/experience progression for characters.
+
+## Scenario & Narrative Development
+
+- [ ] Campaign framework to chain multiple scenarios with persistence.
+- [ ] Event scripting language for cutscenes and triggers.
+- [ ] Save/load system for long-running worlds and branching paths.
+- [ ] Optional multiplayer or networked simulation support.
+
+## Infrastructure & Performance
+
+- [ ] Continuous integration pipeline running tests, linting and type
+      checks.
+- [ ] Benchmark suite with automated performance regression alerts.
+- [ ] Plugin versioning and compatibility management.
+- [ ] Packaging and distribution on PyPI with semantic versioning.
+
+## Documentation & Community
+
+- [ ] Expand `project_spec.md` with concrete examples for every node and
+      system type.
+- [ ] Write step-by-step tutorials and how-to guides.
+- [ ] Publish contribution guidelines and a code of conduct.
+- [ ] Launch a documentation website with interactive examples and API
+      reference.
+- [ ] Organise community challenges to create and share new scenarios.
+

--- a/prompt_ajout_fonc.md
+++ b/prompt_ajout_fonc.md
@@ -24,3 +24,5 @@ Tu travailles sur le projet Nodari. Aujourd’hui, ta mission est d’ajouter **
    - Le **README.md** si cette fonctionnalité est visible ou importante
 
 5. Commets les changements avec un message clair, du type :
+   - `git commit -m "feat: add nouvelle fonctionnalité"`
+


### PR DESCRIPTION
## Summary
- add ambitious multi-part TODO roadmap for future development
- fix prompt instructions and reference TODO in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e58192a483309044b7bed838d245