### PR TITLE
feat: add world seed for deterministic simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ See [project_spec.md](project_spec.md) for the full specification, architecture 
 
 An example configuration file `example_farm.json` demonstrates a minimal world setup loaded via the declarative loader.
 
+Configurations may include a `seed` in the `WorldNode` configuration to ensure
+deterministic simulations.
+
 The engine includes a `LoggingSystem` that prints selected events, offering a basic way to observe simulations from the console.
 
 ## Running the simulation

--- a/example_farm.json
+++ b/example_farm.json
@@ -1,7 +1,7 @@
 {
   "world": {
     "type": "WorldNode",
-    "config": {"width": 100, "height": 100},
+    "config": {"width": 100, "height": 100, "seed": 42},
     "children": [
       {
         "type": "HouseNode",

--- a/nodes/world.py
+++ b/nodes/world.py
@@ -1,17 +1,39 @@
 """World root node."""
 from __future__ import annotations
 
+import random
+
 from core.simnode import SimNode
 from core.plugins import register_node_type
 
 
 class WorldNode(SimNode):
-    """Root container of the simulation."""
+    """Root container of the simulation.
 
-    def __init__(self, width: int = 100, height: int = 100, **kwargs) -> None:
+    Parameters
+    ----------
+    width:
+        Width of the world map.
+    height:
+        Height of the world map.
+    seed:
+        Optional seed for global random number generation to make
+        simulations deterministic.
+    """
+
+    def __init__(
+        self,
+        width: int = 100,
+        height: int = 100,
+        seed: int | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
+        self.seed = seed
+        if seed is not None:
+            random.seed(seed)
 
 
 register_node_type("WorldNode", WorldNode)

--- a/project_spec.md
+++ b/project_spec.md
@@ -175,7 +175,8 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Provide minimal rendering/logging to observe the simulation (LoggingSystem outputs events to console).
 - [x] Add Pygame-based visualization interface.
 - [x] Document architecture and nodes, update README.
-- [ ] Implement seed-based reproducibility (optional).
+- [x] Implement seed-based reproducibility (optional). The ``WorldNode``
+  accepts a ``seed`` to initialise the global RNG for deterministic runs.
 - [x] Prepare foundations for future plugins and scenarios.
 
 ## 6. Contribution Guidelines

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import random
+
+from nodes.world import WorldNode
+
+
+def test_world_seed_reproducibility() -> None:
+    """WorldNode seeds the global RNG for deterministic simulations."""
+    state = random.getstate()
+    try:
+        WorldNode(name="w1", seed=123)
+        seq1 = [random.random() for _ in range(3)]
+        WorldNode(name="w2", seed=123)
+        seq2 = [random.random() for _ in range(3)]
+        assert seq1 == seq2
+
+        WorldNode(name="w3", seed=456)
+        seq3 = [random.random() for _ in range(3)]
+        assert seq1 != seq3
+    finally:
+        random.setstate(state)
+


### PR DESCRIPTION
## Summary
- allow `WorldNode` to seed the global random generator for reproducible runs
- document seed usage and update example configuration
- add unit test ensuring deterministic sequences with identical seeds

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68948afb59c483308412b31552e88b38