### PR TITLE
docs: sync roadmap and expand future possibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project aims to build a modular simulation engine for farm scenarios and beyond. It is designed around reusable nodes, a plugin system and declarative configuration.
 
-See [project_spec.md](project_spec.md) for the full specification, architecture overview and roadmap.
+Project objectives, current progress and the complete roadmap live in [project_spec.md](project_spec.md). The document centralises goals, completed work and upcoming tasks.
 
 An example configuration file `example_farm.json` demonstrates a minimal world setup loaded via the declarative loader.
 
@@ -25,8 +25,20 @@ python run_farm.py
 * Install dependencies listed in `requirements.txt`
 * Run tests with `pytest`
 
+## Roadmap and Tasks
+
+Project objectives, completed milestones and remaining tasks are tracked in [project_spec.md](project_spec.md). A high-level view of upcoming features also appears in [TODO.md](TODO.md).
+
+## Future Possibilities
+
+Thanks to its modular design, the engine can ultimately power a wide range of simulations:
+
+- City management with trade routes and citizen behaviours.
+- Ecosystem and wildlife balance studies.
+- Space-colony survival with life‑support management.
+- Historical recreations exploring alternate timelines.
+- Educational labs demonstrating economic or ecological principles.
+
 ## License
 
 MIT
-
-See [TODO.md](TODO.md) for the full roadmap and upcoming enhancements.

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,12 @@
 # TODO Roadmap
 
-This document extends the checklist in [project_spec.md](project_spec.md)
+This document mirrors the roadmap in [project_spec.md](project_spec.md)
 with ambitious, long‑term tasks. Items are grouped by theme and can be
 checked off as the project evolves.
 
 ## Core Engine Enhancements
 
-- [ ] Implement seed-based reproducibility for deterministic simulations.
+- [x] Implement seed-based reproducibility for deterministic simulations.
 - [ ] Expand the event bus with priority levels and asynchronous
       dispatching.
 - [ ] Support serialising and reloading full world state for snapshots
@@ -14,6 +14,8 @@ checked off as the project evolves.
 - [ ] Provide a scheduling system to update nodes at different rates.
 - [ ] Optimise the update loop for large simulations (profiling,
       micro‑benchmarks).
+- [ ] Hot-reload node logic without restarting simulations.
+- [ ] State diffing and time-travel debugging for deterministic replay.
 
 ## Tools for Creation
 
@@ -27,6 +29,8 @@ checked off as the project evolves.
   - [ ] Plugin manager to enable/disable community packages.
 - [ ] Repository or marketplace for sharing community-created nodes and
       scenarios.
+- [ ] Configuration auto-completion and linting support for editors.
+- [ ] Behaviour scripting DSL with a safe sandbox.
 
 ## Visualization and Rendering
 
@@ -39,6 +43,7 @@ checked off as the project evolves.
 - [ ] Optional 3D rendering backend (e.g., Panda3D) with automatic
       asset mapping from node properties.
 - [ ] Recording and replay tool to capture simulation sessions.
+- [ ] VR/AR viewer for immersive observation.
 
 ## Advanced Simulation Mechanics
 
@@ -50,6 +55,7 @@ checked off as the project evolves.
 - [ ] Combat mechanics including equipment, damage and defence systems.
 - [ ] Behaviour tree library for complex AI decision making.
 - [ ] Modular skill/experience progression for characters.
+- [ ] Procedural world generation for terrain and events.
 
 ## Scenario & Narrative Development
 
@@ -57,6 +63,7 @@ checked off as the project evolves.
 - [ ] Event scripting language for cutscenes and triggers.
 - [ ] Save/load system for long-running worlds and branching paths.
 - [ ] Optional multiplayer or networked simulation support.
+- [ ] Social relationship system tracking friendships and rivalries.
 
 ## Infrastructure & Performance
 
@@ -65,6 +72,8 @@ checked off as the project evolves.
 - [ ] Benchmark suite with automated performance regression alerts.
 - [ ] Plugin versioning and compatibility management.
 - [ ] Packaging and distribution on PyPI with semantic versioning.
+- [ ] Telemetry export to monitor performance and state.
+- [ ] Plugin sandboxing and permission system.
 
 ## Documentation & Community
 
@@ -75,4 +84,6 @@ checked off as the project evolves.
 - [ ] Launch a documentation website with interactive examples and API
       reference.
 - [ ] Organise community challenges to create and share new scenarios.
+- [ ] Auto-generated API reference using Sphinx.
+- [ ] Example scenario pack demonstrating diverse use cases.
 

--- a/project_spec.md
+++ b/project_spec.md
@@ -157,7 +157,9 @@ Steps must be completed in order, each with accompanying unit tests.
 - Provide architecture documentation and explain plugin creation.
 - Maintain the checklist of progress.
 
-## 5. Progress Checklist
+## 5. Progress and Roadmap
+
+### 5.1 Completed
 - [x] Initialise Git repository, environment and dependencies.
 - [x] Implement `SimNode` with event bus and unit tests.
 - [x] Create base `SystemNode` and minimal test.
@@ -175,9 +177,70 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Provide minimal rendering/logging to observe the simulation (LoggingSystem outputs events to console).
 - [x] Add Pygame-based visualization interface.
 - [x] Document architecture and nodes, update README.
-- [x] Implement seed-based reproducibility (optional). The ``WorldNode``
-  accepts a ``seed`` to initialise the global RNG for deterministic runs.
+- [x] Implement seed-based reproducibility. The `WorldNode` accepts a `seed` to initialise the global RNG for deterministic runs.
 - [x] Prepare foundations for future plugins and scenarios.
+
+### 5.2 Upcoming
+#### Core Engine Enhancements
+- [ ] Expand the event bus with priority levels and asynchronous dispatching.
+- [ ] Support serialising and reloading full world state for snapshots and debugging.
+- [ ] Provide a scheduling system to update nodes at different rates.
+- [ ] Optimise the update loop for large simulations (profiling, micro-benchmarks).
+- [ ] Hot-reload node logic without restarting simulations.
+- [ ] State diffing and time-travel debugging for deterministic replay.
+
+#### Tools for Creation
+- [ ] Command-line tool to scaffold new node or system plugins from templates.
+- [ ] Schema validation utility for configuration files (YAML/JSON).
+- [ ] Graphical node editor allowing drag-and-drop composition and export to declarative configs.
+  - [ ] Basic UI to add/remove nodes and edit properties.
+  - [ ] Live simulation preview panel.
+  - [ ] Plugin manager to enable/disable community packages.
+- [ ] Repository or marketplace for sharing community-created nodes and scenarios.
+- [ ] Configuration auto-completion and linting support for editors.
+- [ ] Behaviour scripting DSL with a safe sandbox.
+
+#### Visualization and Rendering
+- [ ] Extend the Pygame viewer with camera controls, zoom and overlays for inventories, needs and events.
+- [ ] Headless rendering mode that streams frames or state for remote dashboards.
+- [ ] Web-based viewer (WebGL/Canvas) to observe simulations in the browser.
+- [ ] Optional 3D rendering backend (e.g., Panda3D) with automatic asset mapping from node properties.
+- [ ] Recording and replay tool to capture simulation sessions.
+- [ ] VR/AR viewer for immersive observation.
+
+#### Advanced Simulation Mechanics
+- [ ] Weather and seasonal systems influencing production rates and character behaviour.
+- [ ] Animal nodes with needs, reproduction and resource generation.
+- [ ] Dynamic economy with fluctuating prices and market events.
+- [ ] Quest or objective system using dedicated `QuestNode` types.
+- [ ] Combat mechanics including equipment, damage and defence systems.
+- [ ] Behaviour tree library for complex AI decision making.
+- [ ] Modular skill/experience progression for characters.
+- [ ] Procedural world generation for terrain and events.
+
+#### Scenario & Narrative Development
+- [ ] Campaign framework to chain multiple scenarios with persistence.
+- [ ] Event scripting language for cutscenes and triggers.
+- [ ] Save/load system for long-running worlds and branching paths.
+- [ ] Optional multiplayer or networked simulation support.
+- [ ] Social relationship system tracking friendships and rivalries.
+
+#### Infrastructure & Performance
+- [ ] Continuous integration pipeline running tests, linting and type checks.
+- [ ] Benchmark suite with automated performance regression alerts.
+- [ ] Plugin versioning and compatibility management.
+- [ ] Packaging and distribution on PyPI with semantic versioning.
+- [ ] Telemetry export to monitor performance and state.
+- [ ] Plugin sandboxing and permission system.
+
+#### Documentation & Community
+- [ ] Expand `project_spec.md` with concrete examples for every node and system type.
+- [ ] Write step-by-step tutorials and how-to guides.
+- [ ] Publish contribution guidelines and a code of conduct.
+- [ ] Launch a documentation website with interactive examples and API reference.
+- [ ] Organise community challenges to create and share new scenarios.
+- [ ] Auto-generated API reference using Sphinx.
+- [ ] Example scenario pack demonstrating diverse use cases.
 
 ## 6. Contribution Guidelines
 - Atomic commits with explicit English messages.
@@ -186,9 +249,9 @@ Steps must be completed in order, each with accompanying unit tests.
 - Document new nodes or systems clearly in code and docs.
 - Update the checklist as tasks evolve or complete.
 
-## 7. Next Steps After the Farm
-- Add weather and seasons influencing production.
-- Introduce animals with needs, reproduction and resource production.
-- Develop a visual editor to assemble nodes and generate configs.
-- Create quest or narrative objectives (QuestNode).
-- Integrate weapons and combat for defence or war scenarios.
+## 7. Future Possibilities
+- Medieval city builders simulating trade routes and citizen needs.
+- Post-apocalyptic survival with scavenging and base management.
+- Ecological simulations exploring predator-prey balance or climate impact.
+- Space-colony management with life support, exploration and diplomacy.
+- Educational scenarios teaching resource planning or sustainability principles.


### PR DESCRIPTION
## Summary
- centralize goals and tasks in project_spec
- mirror roadmap in TODO and highlight upcoming enhancements
- describe imaginative future simulation scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894a4b365e08330b0b2f58b5edb71fa