### PR TITLE
Add water well and warehouse to farm simulation

### DIFF
--- a/RUN_MODE.md
+++ b/RUN_MODE.md
@@ -8,6 +8,7 @@ Ce document décrit le déroulement de la simulation lorsque l'on exécute `run_
 2. **Construction du monde** : `load_simulation_from_file("example_farm.json")` lit la configuration déclarative et instancie l'arbre de nœuds.
 3. **Liaison des producteurs** : chaque `ResourceProducerNode` est relié à l'inventaire présent au même niveau hiérarchique.
 4. **Boucle principale** : une boucle Pygame calcule `dt` et appelle `world.update(dt * TIME_SCALE)`.
+5. **Temps initial** : le `TimeSystem` démarre à 04:00 pour simuler le lever à 6h.
 
 ```mermaid
 flowchart LR
@@ -21,30 +22,29 @@ flowchart LR
 
 ## 2. Structure initiale du monde
 
-L'exemple `example_farm.json` décrit un monde minimal. Le schéma suivant résume les principaux nœuds :
+`example_farm.json` instancie une petite ferme composée de cinq maisons,
+de dix personnages, d'un puits, d'une ferme et d'un entrepôt. Le schéma
+ci-dessous résume les nœuds principaux :
 
 ```
 WorldNode
-├─ HouseNode house1
+├─ HouseNode house1..house5
 │  ├─ TransformNode
-│  └─ InventoryNode house1_inventory
-├─ HouseNode house2
+│  └─ InventoryNode house*_inventory
+├─ FarmNode farm
 │  ├─ TransformNode
-│  └─ InventoryNode house2_inventory
-├─ HouseNode house3
+│  ├─ InventoryNode farm_inventory
+│  └─ ResourceProducerNode farm_producer
+├─ WellNode well
 │  ├─ TransformNode
-│  └─ InventoryNode house3_inventory
-├─ FarmNode farm1
+│  ├─ InventoryNode well_inventory
+│  └─ ResourceProducerNode well_producer
+├─ WarehouseNode warehouse
 │  ├─ TransformNode
-│  ├─ InventoryNode farm1_inventory
-│  └─ ResourceProducerNode producer1
-├─ FarmNode farm2
+│  └─ InventoryNode warehouse_inventory
+├─ CharacterNode jean, marie, ... (10 au total)
 │  ├─ TransformNode
-│  ├─ InventoryNode farm2_inventory
-│  └─ ResourceProducerNode producer2
-├─ CharacterNode worker1/2/3
-│  ├─ TransformNode
-│  ├─ InventoryNode worker*_inventory
+│  ├─ InventoryNode *_inventory
 │  └─ AIBehaviorNode
 ├─ TimeSystem
 ├─ EconomySystem
@@ -93,7 +93,7 @@ Lorsqu'un nœud veut acheter un objet, il émet `buy_request` vers `EconomySyste
 
 ## 4. Visualisation et observabilité
 
-- `PygameViewerSystem` dessine chaque image en parcourant l'arbre de nœuds et en représentant les positions, inventaires et besoins.
+- `PygameViewerSystem` ouvre une fenêtre de 1200x720 pixels et dessine chaque image en parcourant l'arbre de nœuds en représentant les positions, inventaires et besoins.
 - `LoggingSystem` écrit les événements clés (`tick`, `resource_produced`, `inventory_changed`, `need_threshold_reached`, ...).
 
 ## 5. Évolution du monde

--- a/example_farm.json
+++ b/example_farm.json
@@ -1,81 +1,132 @@
 {
   "world": {
     "type": "WorldNode",
-    "config": {"width": 100, "height": 100, "seed": 42},
+    "config": {"width": 240, "height": 144, "seed": 42},
     "children": [
-      {
-        "type": "HouseNode",
-        "id": "house1",
+      {"type": "HouseNode", "id": "house1",
         "children": [
-          {"type": "TransformNode", "config": {"position": [10, 10]}},
+          {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "id": "house1_inventory", "config": {"items": {}}}
         ]
       },
-      {
-        "type": "HouseNode",
-        "id": "house2",
+      {"type": "HouseNode", "id": "house2",
         "children": [
-          {"type": "TransformNode", "config": {"position": [20, 80]}},
+          {"type": "TransformNode", "config": {"position": [20, 120]}},
           {"type": "InventoryNode", "id": "house2_inventory", "config": {"items": {}}}
         ]
       },
-      {
-        "type": "HouseNode",
-        "id": "house3",
+      {"type": "HouseNode", "id": "house3",
         "children": [
-          {"type": "TransformNode", "config": {"position": [80, 20]}},
+          {"type": "TransformNode", "config": {"position": [120, 20]}},
           {"type": "InventoryNode", "id": "house3_inventory", "config": {"items": {}}}
         ]
       },
-      {
-        "type": "FarmNode",
-        "id": "farm1",
+      {"type": "HouseNode", "id": "house4",
         "children": [
-          {"type": "TransformNode", "config": {"position": [60, 60]}},
-          {"type": "InventoryNode", "id": "farm1_inventory", "config": {"items": {}}},
-          {"type": "ResourceProducerNode", "id": "producer1", "config": {"resource": "wheat", "rate_per_tick": 1}}
+          {"type": "TransformNode", "config": {"position": [220, 40]}},
+          {"type": "InventoryNode", "id": "house4_inventory", "config": {"items": {}}}
         ]
       },
-      {
-        "type": "FarmNode",
-        "id": "farm2",
+      {"type": "HouseNode", "id": "house5",
         "children": [
-          {"type": "TransformNode", "config": {"position": [80, 80]}},
-          {"type": "InventoryNode", "id": "farm2_inventory", "config": {"items": {}}},
-          {"type": "ResourceProducerNode", "id": "producer2", "config": {"resource": "wheat", "rate_per_tick": 1}}
+          {"type": "TransformNode", "config": {"position": [200, 120]}},
+          {"type": "InventoryNode", "id": "house5_inventory", "config": {"items": {}}}
         ]
       },
-      {
-        "type": "CharacterNode",
-        "id": "worker1",
+      {"type": "FarmNode", "id": "farm",
         "children": [
-          {"type": "TransformNode", "config": {"position": [10, 10]}},
-          {"type": "InventoryNode", "id": "worker1_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm1", "home_inventory": "house1_inventory", "lunch_position": [50, 50], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "TransformNode", "config": {"position": [120, 80]}},
+          {"type": "InventoryNode", "id": "farm_inventory", "config": {"items": {}}},
+          {"type": "ResourceProducerNode", "id": "farm_producer", "config": {"resource": "wheat", "rate_per_tick": 1, "inputs": {"water": 1}, "auto": false}}
         ]
       },
-      {
-        "type": "CharacterNode",
-        "id": "worker2",
+      {"type": "WellNode", "id": "well",
         "children": [
-          {"type": "TransformNode", "config": {"position": [20, 80]}},
-          {"type": "InventoryNode", "id": "worker2_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm2", "home_inventory": "house2_inventory", "lunch_position": [50, 50], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "TransformNode", "config": {"position": [40, 70]}},
+          {"type": "InventoryNode", "id": "well_inventory", "config": {"items": {"water": 0}}},
+          {"type": "ResourceProducerNode", "id": "well_producer", "config": {"resource": "water", "rate_per_tick": 1}}
         ]
       },
-      {
-        "type": "CharacterNode",
-        "id": "worker3",
+      {"type": "WarehouseNode", "id": "warehouse",
         "children": [
-          {"type": "TransformNode", "config": {"position": [80, 20]}},
-          {"type": "InventoryNode", "id": "worker3_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm1", "home_inventory": "house3_inventory", "lunch_position": [50, 50], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "TransformNode", "config": {"position": [200, 70]}},
+          {"type": "InventoryNode", "id": "warehouse_inventory", "config": {"items": {}}}
         ]
       },
-      {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60}},
+      {"type": "CharacterNode", "id": "jean",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [20, 20]}},
+          {"type": "InventoryNode", "id": "jean_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "marie",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [20, 20]}},
+          {"type": "InventoryNode", "id": "marie_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "pierre",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [20, 120]}},
+          {"type": "InventoryNode", "id": "pierre_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "julie",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [20, 120]}},
+          {"type": "InventoryNode", "id": "julie_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "paul",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [120, 20]}},
+          {"type": "InventoryNode", "id": "paul_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "claire",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [120, 20]}},
+          {"type": "InventoryNode", "id": "claire_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "jacques",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [220, 40]}},
+          {"type": "InventoryNode", "id": "jacques_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "sophie",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [220, 40]}},
+          {"type": "InventoryNode", "id": "sophie_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "louis",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [200, 120]}},
+          {"type": "InventoryNode", "id": "louis_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "CharacterNode", "id": "anne",
+        "children": [
+          {"type": "TransformNode", "config": {"position": [200, 120]}},
+          {"type": "InventoryNode", "id": "anne_inventory", "config": {"items": {}}},
+          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+        ]
+      },
+      {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60, "start_time": 14400}},
       {"type": "EconomySystem", "id": "economy"},
       {"type": "LoggingSystem", "id": "logger"},
-      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 800, "height": 600, "scale": 5}}
+      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 1200, "height": 720, "scale": 5}}
     ]
   }
 }

--- a/nodes/warehouse.py
+++ b/nodes/warehouse.py
@@ -1,0 +1,15 @@
+"""Warehouse node for storing goods."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class WarehouseNode(SimNode):
+    """Represents a storage building."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+
+register_node_type("WarehouseNode", WarehouseNode)

--- a/nodes/well.py
+++ b/nodes/well.py
@@ -1,0 +1,15 @@
+"""Well node producing water."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class WellNode(SimNode):
+    """Simple well where characters can collect water."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+
+register_node_type("WellNode", WellNode)

--- a/run_farm.py
+++ b/run_farm.py
@@ -24,6 +24,8 @@ load_plugins(
         "nodes.ai_behavior",
         "nodes.transform",
         "nodes.house",
+        "nodes.well",
+        "nodes.warehouse",
         "systems.time",
         "systems.economy",
         "systems.logger",

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -14,6 +14,8 @@ from nodes.transform import TransformNode
 from nodes.character import CharacterNode
 from nodes.farm import FarmNode
 from nodes.house import HouseNode
+from nodes.well import WellNode
+from nodes.warehouse import WarehouseNode
 from systems.time import TimeSystem
 
 
@@ -83,6 +85,10 @@ class PygameViewerSystem(SystemNode):
                     pygame.draw.rect(self.screen, (150, 100, 50), (*pos, 20, 20))
                 elif isinstance(parent, HouseNode):
                     pygame.draw.rect(self.screen, (50, 100, 200), (*pos, 20, 20))
+                elif isinstance(parent, WellNode):
+                    pygame.draw.circle(self.screen, (0, 100, 200), pos, 7)
+                elif isinstance(parent, WarehouseNode):
+                    pygame.draw.rect(self.screen, (150, 150, 150), (*pos, 20, 20))
                 else:
                     pygame.draw.circle(self.screen, (200, 200, 200), pos, 3)
             if isinstance(node, TimeSystem):

--- a/systems/time.py
+++ b/systems/time.py
@@ -8,13 +8,19 @@ from core.plugins import register_node_type
 class TimeSystem(SystemNode):
     """Emit a `tick` event based on elapsed time and track the day cycle."""
 
-    def __init__(self, tick_duration: float = 1.0, phase_length: int = 10, **kwargs) -> None:
+    def __init__(
+        self,
+        tick_duration: float = 1.0,
+        phase_length: int = 10,
+        start_time: float = 0.0,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.tick_duration = tick_duration
         self.phase_length = phase_length
         self.current_tick = 0
         self.phase = 0
-        self.current_time = 0.0  # seconds since start of day
+        self.current_time = start_time  # seconds since start of day
         self._accumulator = 0.0
         self.day_length = 24 * 3600.0
 

--- a/tests/test_resource_producer.py
+++ b/tests/test_resource_producer.py
@@ -7,3 +7,17 @@ def test_resource_production():
     producer = ResourceProducerNode(resource="wheat", rate_per_tick=1, output_inventory=inv)
     producer.update(1)
     assert inv.items["wheat"] == 1
+
+
+def test_manual_production():
+    inv = InventoryNode(name="farm_inv", items={"water": 5})
+    producer = ResourceProducerNode(
+        resource="wheat",
+        rate_per_tick=2,
+        inputs={"water": 1},
+        output_inventory=inv,
+        auto=False,
+    )
+    producer.work()
+    assert inv.items["wheat"] == 2
+    assert inv.items["water"] == 4


### PR DESCRIPTION
## Summary
- extend resource producer with optional manual activation and work method
- enhance AI behaviour to fetch water, deliver wheat and support new buildings
- add well and warehouse nodes, update viewer and example farm configuration
- start time at 04:00 and document new simulation flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894abb562748330957091c512d955d7