### PR TITLE
Refine simulation control and viewer UI

### DIFF
--- a/example_farm.json
+++ b/example_farm.json
@@ -57,70 +57,70 @@
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "id": "jean_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "marie",
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "id": "marie_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "pierre",
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 120]}},
           {"type": "InventoryNode", "id": "pierre_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "julie",
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 120]}},
           {"type": "InventoryNode", "id": "julie_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "paul",
         "children": [
           {"type": "TransformNode", "config": {"position": [120, 20]}},
           {"type": "InventoryNode", "id": "paul_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "claire",
         "children": [
           {"type": "TransformNode", "config": {"position": [120, 20]}},
           {"type": "InventoryNode", "id": "claire_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "jacques",
         "children": [
           {"type": "TransformNode", "config": {"position": [220, 40]}},
           {"type": "InventoryNode", "id": "jacques_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "sophie",
         "children": [
           {"type": "TransformNode", "config": {"position": [220, 40]}},
           {"type": "InventoryNode", "id": "sophie_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "louis",
         "children": [
           {"type": "TransformNode", "config": {"position": [200, 120]}},
           {"type": "InventoryNode", "id": "louis_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "CharacterNode", "id": "anne",
         "children": [
           {"type": "TransformNode", "config": {"position": [200, 120]}},
           {"type": "InventoryNode", "id": "anne_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 0.05, "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
       {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60, "start_time": 14400}},

--- a/nodes/ai_behavior.py
+++ b/nodes/ai_behavior.py
@@ -12,6 +12,8 @@ from .need import NeedNode
 from .transform import TransformNode
 from systems.time import TimeSystem
 
+BASE_SPEED = 0.01
+
 
 class AIBehaviorNode(SimNode):
     """Very small behaviour for a farmer.
@@ -23,7 +25,8 @@ class AIBehaviorNode(SimNode):
     def __init__(
         self,
         target_inventory: Optional[InventoryNode] = None,
-        speed: float = 10.0,
+        speed: float = 5.0,
+        random_speed: float = 2.0,
         home: Optional[str | SimNode] = None,
         work: Optional[str | SimNode] = None,
         home_inventory: Optional[str | InventoryNode] = None,
@@ -39,7 +42,8 @@ class AIBehaviorNode(SimNode):
     ) -> None:
         super().__init__(**kwargs)
         self.target_inventory = target_inventory
-        self.speed = speed
+        self.speed = BASE_SPEED * speed
+        self.random_speed = BASE_SPEED * random_speed
         self.home = home
         self.work = work
         self.home_inventory = home_inventory
@@ -70,8 +74,8 @@ class AIBehaviorNode(SimNode):
                 self._handle_work(transform, target, dt)
         elif transform is not None:
             # fallback random walk
-            transform.position[0] += random.uniform(-1, 1) * self.speed * dt
-            transform.position[1] += random.uniform(-1, 1) * self.speed * dt
+            transform.position[0] += random.uniform(-1, 1) * self.random_speed * dt
+            transform.position[1] += random.uniform(-1, 1) * self.random_speed * dt
         super().update(dt)
 
     def _on_need(self, emitter: SimNode, event_name: str, payload) -> None:
@@ -329,7 +333,7 @@ class AIBehaviorNode(SimNode):
         if self._sleeping:
             transform.position[0], transform.position[1] = target[0], target[1]
             return
-        jitter = 0.5
+        jitter = self.random_speed * 25
         transform.position[0] = target[0] + random.uniform(-jitter, jitter)
         transform.position[1] = target[1] + random.uniform(-jitter, jitter)
 

--- a/run_farm.py
+++ b/run_farm.py
@@ -66,7 +66,7 @@ if not any(isinstance(c, PygameViewerSystem) for c in world.children):
 
 
 FPS = 24
-TIME_SCALE = 86400 / 60  # 1 journée simulée = 1 minute réelle
+TIME_SCALE = 86400 / 120  # 1 journée simulée = 2 minutes réelles
 
 clock = pygame.time.Clock()
 

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -18,6 +18,14 @@ from nodes.well import WellNode
 from nodes.warehouse import WarehouseNode
 from systems.time import TimeSystem
 
+BUILDING_SIZES = {
+    FarmNode: (60, 40),
+    HouseNode: (40, 40),
+    WarehouseNode: (50, 30),
+}
+WELL_RADIUS = 10
+CHAR_RADIUS = 5
+
 
 class PygameViewerSystem(SystemNode):
     """Render simulation state using a simple Pygame window.
@@ -38,8 +46,9 @@ class PygameViewerSystem(SystemNode):
         pygame.init()
         self.screen = pygame.display.set_mode((width, height))
         pygame.display.set_caption(self.name)
-        self.font = pygame.font.Font(None, 24)
+        self.font = pygame.font.Font(None, 16)
         self.scale = scale
+        self.panel_width = 200
 
     # ------------------------------------------------------------------
     # Helpers
@@ -80,30 +89,43 @@ class PygameViewerSystem(SystemNode):
                 x, y = node.position
                 pos = (int(x * self.scale), int(y * self.scale))
                 if isinstance(parent, CharacterNode):
-                    pygame.draw.circle(self.screen, (0, 200, 0), pos, 5)
+                    pygame.draw.circle(self.screen, (0, 200, 0), pos, CHAR_RADIUS)
                 elif isinstance(parent, FarmNode):
-                    pygame.draw.rect(self.screen, (150, 100, 50), (*pos, 20, 20))
+                    w, h = BUILDING_SIZES[FarmNode]
+                    rect = pygame.Rect(0, 0, w, h)
+                    rect.center = pos
+                    pygame.draw.rect(self.screen, (150, 100, 50), rect)
                 elif isinstance(parent, HouseNode):
-                    pygame.draw.rect(self.screen, (50, 100, 200), (*pos, 20, 20))
+                    w, h = BUILDING_SIZES[HouseNode]
+                    rect = pygame.Rect(0, 0, w, h)
+                    rect.center = pos
+                    pygame.draw.rect(self.screen, (50, 100, 200), rect)
                 elif isinstance(parent, WellNode):
-                    pygame.draw.circle(self.screen, (0, 100, 200), pos, 7)
+                    pygame.draw.circle(self.screen, (0, 100, 200), pos, WELL_RADIUS)
                 elif isinstance(parent, WarehouseNode):
-                    pygame.draw.rect(self.screen, (150, 150, 150), (*pos, 20, 20))
+                    w, h = BUILDING_SIZES[WarehouseNode]
+                    rect = pygame.Rect(0, 0, w, h)
+                    rect.center = pos
+                    pygame.draw.rect(self.screen, (150, 150, 150), rect)
                 else:
                     pygame.draw.circle(self.screen, (200, 200, 200), pos, 3)
             if isinstance(node, TimeSystem):
                 time_sys = node
+        panel_rect = pygame.Rect(
+            self.screen.get_width() - self.panel_width, 0, self.panel_width, self.screen.get_height()
+        )
+        pygame.draw.rect(self.screen, (20, 20, 20), panel_rect)
 
         for i, text in enumerate(lines):
             surf = self.font.render(text, True, (220, 220, 220))
-            self.screen.blit(surf, (10, 30 + i * 20))
+            self.screen.blit(surf, (panel_rect.x + 10, 30 + i * 18))
 
         if time_sys is not None:
             hours = int(time_sys.current_time // 3600) % 24
             minutes = int((time_sys.current_time % 3600) // 60)
             time_text = f"{hours:02d}:{minutes:02d}"
             surf = self.font.render(time_text, True, (220, 220, 220))
-            self.screen.blit(surf, (10, 10))
+            self.screen.blit(surf, (panel_rect.x + 10, 10))
 
         pygame.display.flip()
         super().update(dt)


### PR DESCRIPTION
## Summary
- Allow day cycles to last two real-time minutes
- Expose character movement and random walk speeds via simple 1-10 settings
- Render buildings from their centres with distinct sizes and add a right-side info panel

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894d5d49bf083309e78dc9491deb37a