### PR TITLE
Introduce DistanceSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An example configuration file `example_farm.json` demonstrates a minimal world s
 Configurations may include a `seed` in the `WorldNode` configuration to ensure
 deterministic simulations.
 
-The engine includes a `LoggingSystem` that prints selected events, offering a basic way to observe simulations from the console.
+The engine includes a `LoggingSystem` that prints selected events, offering a basic way to observe simulations from the console. A `DistanceSystem` computes distances between positioned nodes to support spatial reasoning.
 
 ## Running the simulation
 

--- a/example_farm.json
+++ b/example_farm.json
@@ -126,6 +126,7 @@
       {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60, "start_time": 14400}},
       {"type": "EconomySystem", "id": "economy"},
       {"type": "LoggingSystem", "id": "logger"},
+      {"type": "DistanceSystem", "id": "distance"},
       {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 1200, "height": 720, "scale": 5}}
     ]
   }

--- a/project_spec.md
+++ b/project_spec.md
@@ -34,6 +34,7 @@ Global behaviours live in `SystemNode` subclasses which traverse the tree or lis
 - **TimeSystem** – manages time flow (ticks, day/night cycles, seasons) and emits `tick` and `phase_changed` events.
 - **EconomySystem** – listens to buy/sell events, transfers money and updates prices if necessary.
 - **WeatherSystem** – determines current weather, emits events like `rain_started` or `drought` and exposes state.
+- **DistanceSystem** – computes distances between nodes with positions and answers distance queries.
 
 ### 3.3 Generic Nodes
 For modelling the farm and inhabitants:
@@ -176,6 +177,7 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Write integration tests for farmer working, eating and sleeping.
 - [x] Provide minimal rendering/logging to observe the simulation (LoggingSystem outputs events to console).
 - [x] Add Pygame-based visualization interface.
+- [x] Introduce `DistanceSystem` for distance calculations between nodes.
 - [x] Document architecture and nodes, update README.
 - [x] Implement seed-based reproducibility. The `WorldNode` accepts a `seed` to initialise the global RNG for deterministic runs.
 - [x] Prepare foundations for future plugins and scenarios.

--- a/run_farm.py
+++ b/run_farm.py
@@ -29,6 +29,7 @@ load_plugins(
         "systems.time",
         "systems.economy",
         "systems.logger",
+        "systems.distance",
         "systems.pygame_viewer",
     ]
 )

--- a/systems/distance.py
+++ b/systems/distance.py
@@ -1,0 +1,39 @@
+"""System providing distance calculations between nodes."""
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.transform import TransformNode
+
+
+class DistanceSystem(SystemNode):
+    """Respond to distance queries using node positions."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.on_event("distance_request", self._on_distance_request)
+
+    def _on_distance_request(self, emitter, event_name, payload) -> None:
+        node_a: SimNode = payload["a"]
+        node_b: SimNode = payload["b"]
+        payload["distance"] = self.measure_distance(node_a, node_b)
+        self.emit("distance_result", payload)
+
+    def measure_distance(self, node_a: SimNode, node_b: SimNode) -> float:
+        ax, ay = self._get_position(node_a)
+        bx, by = self._get_position(node_b)
+        return math.hypot(ax - bx, ay - by)
+
+    def _get_position(self, node: SimNode) -> Tuple[float, float]:
+        if isinstance(node, TransformNode):
+            return tuple(node.position)
+        for child in node.children:
+            if isinstance(child, TransformNode):
+                return tuple(child.position)
+        raise ValueError(f"Node '{node.name}' has no TransformNode")
+
+
+register_node_type("DistanceSystem", DistanceSystem)

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,0 +1,30 @@
+from core.simnode import SimNode
+from nodes.transform import TransformNode
+from systems.distance import DistanceSystem
+
+
+def _make_node(name: str, pos):
+    node = SimNode(name=name)
+    TransformNode(position=list(pos), parent=node)
+    return node
+
+
+def test_measure_distance():
+    system = DistanceSystem()
+    a = _make_node("a", (0, 0))
+    b = _make_node("b", (3, 4))
+    assert system.measure_distance(a, b) == 5
+
+
+def test_distance_event():
+    system = DistanceSystem()
+    a = _make_node("a", (0, 0))
+    b = _make_node("b", (0, 5))
+    result = {}
+
+    def handler(emitter, event_name, payload):
+        result["distance"] = payload["distance"]
+
+    system.on_event("distance_result", handler)
+    system.emit("distance_request", {"a": a, "b": b})
+    assert result["distance"] == 5


### PR DESCRIPTION
## Summary
- add DistanceSystem to compute distances between nodes with positions
- document distance support and include system in example configuration
- cover distance queries with dedicated tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e7fc20b883309fb46373f52b5654