### PR TITLE
feat(core): add async event bus with priorities

### DIFF
--- a/project_spec.md
+++ b/project_spec.md
@@ -184,7 +184,7 @@ Steps must be completed in order, each with accompanying unit tests.
 
 ### 5.2 Upcoming
 #### Core Engine Enhancements
-- [ ] Expand the event bus with priority levels and asynchronous dispatching.
+- [x] Expand the event bus with priority levels and asynchronous dispatching. Handlers now accept a priority and asynchronous handlers are supported via ``emit_async``.
 - [ ] Support serialising and reloading full world state for snapshots and debugging.
 - [ ] Provide a scheduling system to update nodes at different rates.
 - [ ] Optimise the update loop for large simulations (profiling, micro-benchmarks).

--- a/tests/test_simnode.py
+++ b/tests/test_simnode.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from core.simnode import SimNode
 
 
@@ -22,3 +24,36 @@ def test_event_propagation_to_sibling():
     b.on_event("ping", handler)
     a.emit("ping", {"x": 1})
     assert received == [("a", 1)]
+
+
+def test_event_priority():
+    node = SimNode(name="node")
+    call_order = []
+
+    def low_handler(_emitter, _event, _payload):
+        call_order.append("low")
+
+    def high_handler(_emitter, _event, _payload):
+        call_order.append("high")
+
+    node.on_event("test", low_handler, priority=0)
+    node.on_event("test", high_handler, priority=10)
+
+    node.emit("test")
+
+    assert call_order == ["high", "low"]
+
+
+def test_async_dispatch():
+    node = SimNode(name="node")
+    received = []
+
+    async def handler(emitter, event, payload):
+        await asyncio.sleep(0.01)
+        received.append(payload["value"])
+
+    node.on_event("async", handler)
+
+    asyncio.run(node.emit_async("async", {"value": 42}))
+
+    assert received == [42]


### PR DESCRIPTION
## Summary
- allow event handlers to register with priority levels
- add asynchronous event dispatch support
- document event bus improvements in project spec

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f8dc3bb883308c67353c71e0c865