### PR TITLE
Add world snapshot serialization and loading

### DIFF
--- a/core/simnode.py
+++ b/core/simnode.py
@@ -155,11 +155,27 @@ class SimNode:
         for child in list(self.children):
             child.update(dt)
 
+    def _serialize_value(self, value: Any) -> Any:
+        """Serialise *value* supporting nested structures and node refs."""
+        if isinstance(value, SimNode):
+            return value.name
+        if isinstance(value, list):
+            return [self._serialize_value(v) for v in value]
+        if isinstance(value, dict):
+            return {k: self._serialize_value(v) for k, v in value.items()}
+        return value
+
     def serialize(self) -> Dict[str, Any]:
-        """Return a serialisable representation of this node."""
+        """Return a serialisable representation of this node with state."""
+        state = {
+            k: self._serialize_value(v)
+            for k, v in self.__dict__.items()
+            if k not in {"name", "parent", "children", "_listeners"}
+        }
         return {
             "name": self.name,
             "type": self.__class__.__name__,
+            "state": state,
             "children": [child.serialize() for child in self.children],
         }
 

--- a/core/snapshot.py
+++ b/core/snapshot.py
@@ -1,0 +1,46 @@
+"""Utilities to save and load full simulation state snapshots."""
+from __future__ import annotations
+
+import inspect
+from typing import Any, Dict, Optional
+
+from .plugins import get_node_type
+from .simnode import SimNode
+
+
+def serialize_world(root: SimNode) -> Dict[str, Any]:
+    """Serialise the whole simulation tree starting at *root*."""
+    return root.serialize()
+
+
+def _deserialize_node(data: Dict[str, Any], parent: Optional[SimNode] = None) -> SimNode:
+    cls = get_node_type(data["type"])
+    state: Dict[str, Any] = dict(data.get("state", {}))
+
+    sig = inspect.signature(cls.__init__)
+    init_kwargs: Dict[str, Any] = {}
+    for name, param in list(sig.parameters.items())[1:]:
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.POSITIONAL_ONLY,
+        ):
+            continue
+        if name in state:
+            init_kwargs[name] = state.pop(name)
+        elif param.default is inspect._empty:
+            raise TypeError(f"Missing required parameter '{name}' for {cls.__name__}")
+
+    node = cls(name=data.get("name"), parent=parent, **init_kwargs)
+
+    for key, value in state.items():
+        setattr(node, key, value)
+
+    for child_data in data.get("children", []):
+        _deserialize_node(child_data, node)
+    return node
+
+
+def deserialize_world(data: Dict[str, Any]) -> SimNode:
+    """Rebuild a simulation tree from previously serialised *data*."""
+    return _deserialize_node(data, None)

--- a/project_spec.md
+++ b/project_spec.md
@@ -185,7 +185,7 @@ Steps must be completed in order, each with accompanying unit tests.
 ### 5.2 Upcoming
 #### Core Engine Enhancements
 - [x] Expand the event bus with priority levels and asynchronous dispatching. Handlers now accept a priority and asynchronous handlers are supported via ``emit_async``.
-- [ ] Support serialising and reloading full world state for snapshots and debugging.
+- [x] Support serialising and reloading full world state for snapshots and debugging.
 - [ ] Provide a scheduling system to update nodes at different rates.
 - [ ] Optimise the update loop for large simulations (profiling, micro-benchmarks).
 - [ ] Hot-reload node logic without restarting simulations.

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,36 @@
+from core.snapshot import serialize_world, deserialize_world
+from nodes.world import WorldNode
+from nodes.inventory import InventoryNode
+from nodes.need import NeedNode
+from nodes.character import CharacterNode
+from nodes.transform import TransformNode
+from nodes.ai_behavior import AIBehaviorNode
+
+
+def test_snapshot_roundtrip():
+    world = WorldNode(name="world")
+    home = InventoryNode(name="home", items={}, parent=world)
+    char = CharacterNode(name="char", parent=world)
+    inv = InventoryNode(name="inv", items={"wheat": 3}, parent=char)
+    NeedNode(name="hunger", need_name="hunger", threshold=10, increase_rate=1.0, value=5.0, parent=char)
+    TransformNode(name="pos", position=[1.0, 2.0], parent=char)
+    ai = AIBehaviorNode(name="ai", target_inventory=inv, home="home", parent=char)
+    ai._idle = True
+
+    data = serialize_world(world)
+    restored = deserialize_world(data)
+
+    new_char = next(child for child in restored.children if child.name == "char")
+    inv_restored = next(
+        child for child in new_char.children if isinstance(child, InventoryNode) and child.name == "inv"
+    )
+    need_restored = next(child for child in new_char.children if isinstance(child, NeedNode))
+    ai_restored = next(child for child in new_char.children if isinstance(child, AIBehaviorNode))
+
+    assert inv_restored.items["wheat"] == 3
+    assert need_restored.value == 5.0
+    assert ai_restored._idle is True
+    # target inventory restored as reference string
+    assert ai_restored.target_inventory == "inv"
+    ai_restored._resolve_references()
+    assert ai_restored.home is not None and ai_restored.home.name == "home"


### PR DESCRIPTION
## Summary
- extend `SimNode` serialization to include node state and references
- add snapshot utilities to rebuild a node tree from serialized data
- record snapshot round-trip in new unit test
- mark world-state snapshot support as complete in project spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689505f1594083309e7193642509b532