### PR TITLE
Add SchedulerSystem for interval-based node updates

### DIFF
--- a/core/simnode.py
+++ b/core/simnode.py
@@ -26,6 +26,9 @@ class SimNode:
         self.children: List[SimNode] = []
         # Mapping of event name to list of (priority, handler)
         self._listeners: Dict[str, List[Tuple[int, EventHandler]]] = {}
+        # When ``True`` the node is excluded from automatic updates and must
+        # be advanced manually (e.g. by a scheduler system).
+        self._manual_update = False
         if parent is not None:
             parent.add_child(self)
 
@@ -153,6 +156,9 @@ class SimNode:
     def update(self, dt: float) -> None:
         """Update the node for a simulation tick."""
         for child in list(self.children):
+            if getattr(child, "_manual_update", False):
+                # Scheduled nodes are updated externally and skipped here.
+                continue
             child.update(dt)
 
     def _serialize_value(self, value: Any) -> Any:

--- a/project_spec.md
+++ b/project_spec.md
@@ -186,7 +186,7 @@ Steps must be completed in order, each with accompanying unit tests.
 #### Core Engine Enhancements
 - [x] Expand the event bus with priority levels and asynchronous dispatching. Handlers now accept a priority and asynchronous handlers are supported via ``emit_async``.
 - [x] Support serialising and reloading full world state for snapshots and debugging.
-- [ ] Provide a scheduling system to update nodes at different rates.
+- [x] Provide a scheduling system to update nodes at different rates (``SchedulerSystem`` allows manual update intervals).
 - [ ] Optimise the update loop for large simulations (profiling, micro-benchmarks).
 - [ ] Hot-reload node logic without restarting simulations.
 - [ ] State diffing and time-travel debugging for deterministic replay.

--- a/systems/scheduler.py
+++ b/systems/scheduler.py
@@ -1,0 +1,46 @@
+"""Scheduler system to update nodes at individual intervals."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from core.simnode import SimNode, SystemNode
+from core.plugins import register_node_type
+
+
+@dataclass
+class _Task:
+    node: SimNode
+    interval: float
+    acc: float = 0.0
+
+
+class SchedulerSystem(SystemNode):
+    """Call ``update`` on registered nodes at specific intervals."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._tasks: List[_Task] = []
+
+    def schedule(self, node: SimNode, interval: float) -> None:
+        """Schedule *node* to be updated every *interval* seconds."""
+        node._manual_update = True
+        self._tasks.append(_Task(node=node, interval=interval))
+
+    def unschedule(self, node: SimNode) -> None:
+        """Remove *node* from scheduling."""
+        for i, task in enumerate(list(self._tasks)):
+            if task.node is node:
+                del self._tasks[i]
+        node._manual_update = False
+
+    def update(self, dt: float) -> None:
+        for task in self._tasks:
+            task.acc += dt
+            while task.acc >= task.interval:
+                task.acc -= task.interval
+                task.node.update(task.interval)
+        super().update(dt)
+
+
+register_node_type("SchedulerSystem", SchedulerSystem)

--- a/tests/test_scheduler_system.py
+++ b/tests/test_scheduler_system.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from core.simnode import SimNode
+from nodes.world import WorldNode
+from systems.scheduler import SchedulerSystem
+
+
+class DummyNode(SimNode):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.count = 0
+
+    def update(self, dt: float) -> None:
+        self.count += 1
+        super().update(dt)
+
+
+def test_scheduler_updates_nodes_at_intervals():
+    world = WorldNode(name="world")
+    scheduler = SchedulerSystem(parent=world)
+    fast = DummyNode(parent=world)
+    slow = DummyNode(parent=world)
+
+    scheduler.schedule(fast, interval=1.0)
+    scheduler.schedule(slow, interval=2.0)
+
+    for _ in range(5):
+        world.update(1.0)
+
+    assert fast.count == 5
+    assert slow.count == 2


### PR DESCRIPTION
## Summary
- support manual scheduling by skipping auto-updates on flagged nodes
- introduce SchedulerSystem to run node updates at custom intervals
- record progress in project_spec checklist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950c2ae9208330b0a82e366c6c73a6