### PR TITLE
Optimize update loop with cached child list

### DIFF
--- a/project_spec.md
+++ b/project_spec.md
@@ -187,7 +187,8 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Expand the event bus with priority levels and asynchronous dispatching. Handlers now accept a priority and asynchronous handlers are supported via ``emit_async``.
 - [x] Support serialising and reloading full world state for snapshots and debugging.
 - [x] Provide a scheduling system to update nodes at different rates (``SchedulerSystem`` allows manual update intervals).
-- [ ] Optimise the update loop for large simulations (profiling, micro-benchmarks).
+- [x] Optimise the update loop for large simulations (profiling, micro-benchmarks).
+-   Cached immutable child lists avoid per-tick allocations in tight loops.
 - [ ] Hot-reload node logic without restarting simulations.
 - [ ] State diffing and time-travel debugging for deterministic replay.
 


### PR DESCRIPTION
## Summary
- cache SimNode child list and reuse between updates to avoid per-tick allocations
- add tests validating child list caching and stable updates when modifying children mid-tick
- mark update-loop optimization task as complete

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68950ddf0a58833098e2fce17b736d27