### PR TITLE
feat: add event timestamps and distance caching

### DIFF
--- a/docs/cleaning_checklist.md
+++ b/docs/cleaning_checklist.md
@@ -1,6 +1,6 @@
 # Checklist de nettoyage
 
-- [ ] Permettre d'arrêter la propagation d'un évènement et ajouter des horodatages.
+- [x] Permettre d'arrêter la propagation d'un évènement et ajouter des horodatages.
 - [ ] Utiliser `SchedulerSystem` pour planifier les mises à jour des nœuds lents (`NeedNode`, IA...).
 - [ ] Implémenter un `WeatherSystem` impactant la production et les comportements.
 - [ ] Refactorer `AIBehaviorNode` :
@@ -9,8 +9,8 @@
   - [ ] Résoudre les références lors du chargement.
   - [ ] Paramétrer durées, vitesses et seuils via la configuration.
   - [ ] Confier la cadence de mise à jour au `SchedulerSystem`.
-- [ ] Mettre en cache les distances ou introduire un index spatial.
-- [ ] Étendre `SimNode.serialize` pour inclure positions, inventaires et besoins.
+- [x] Mettre en cache les distances ou introduire un index spatial.
+- [x] Étendre `SimNode.serialize` pour inclure positions, inventaires et besoins.
 - [ ] Enrichir `EconomySystem` avec une économie dynamique.
 - [ ] Permettre la sérialisation complète et le rechargement de l'état du monde.
 - [ ] Créer des outils de création (templates, validation de schéma, éditeur graphique).

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -34,7 +34,7 @@ Global behaviours live in `SystemNode` subclasses which traverse the tree or lis
 - **TimeSystem** – manages time flow (ticks, day/night cycles, seasons) and emits `tick` and `phase_changed` events.
 - **EconomySystem** – listens to buy/sell events, transfers money and updates prices if necessary.
 - **WeatherSystem** – determines current weather, emits events like `rain_started` or `drought` and exposes state.
-- **DistanceSystem** – computes distances between nodes with positions and answers distance queries in meters.
+- **DistanceSystem** – computes distances between nodes with positions, caches results each tick and answers distance queries in meters.
 
 ### 3.3 Generic Nodes
 For modelling the farm and inhabitants:
@@ -178,13 +178,14 @@ Steps must be completed in order, each with accompanying unit tests.
 - [x] Provide minimal rendering/logging to observe the simulation (LoggingSystem outputs events to console).
 - [x] Add Pygame-based visualization interface.
 - [x] Introduce `DistanceSystem` for distance calculations between nodes.
+- [x] Cache distance measurements for faster repeated queries.
 - [x] Document architecture and nodes, update README.
 - [x] Implement seed-based reproducibility. The `WorldNode` accepts a `seed` to initialise the global RNG for deterministic runs.
 - [x] Prepare foundations for future plugins and scenarios.
 
 ### 5.2 Upcoming
 #### Core Engine Enhancements
-- [x] Expand the event bus with priority levels and asynchronous dispatching. Handlers now accept a priority and asynchronous handlers are supported via ``emit_async``.
+- [x] Expand the event bus with priority levels, asynchronous dispatching, stoppable propagation and automatic event timestamps. Handlers now accept a priority and asynchronous handlers are supported via ``emit_async``.
 - [x] Support serialising and reloading full world state for snapshots and debugging.
 - [x] Provide a scheduling system to update nodes at different rates (``SchedulerSystem`` allows manual update intervals).
 - [x] Optimise the update loop for large simulations (profiling, micro-benchmarks).

--- a/systems/distance.py
+++ b/systems/distance.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import math
-from typing import Tuple
+from typing import Dict, Tuple
 
 from core.simnode import SystemNode, SimNode
 from core.plugins import register_node_type
@@ -15,6 +15,7 @@ class DistanceSystem(SystemNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.on_event("distance_request", self._on_distance_request)
+        self._cache: Dict[Tuple[int, int], float] = {}
 
     def _on_distance_request(self, emitter, event_name, payload) -> None:
         node_a: SimNode = payload["a"]
@@ -23,9 +24,14 @@ class DistanceSystem(SystemNode):
         self.emit("distance_result", payload)
 
     def measure_distance(self, node_a: SimNode, node_b: SimNode) -> float:
+        key = tuple(sorted((id(node_a), id(node_b))))
+        if key in self._cache:
+            return self._cache[key]
         ax, ay = self._get_position(node_a)
         bx, by = self._get_position(node_b)
-        return math.hypot(ax - bx, ay - by)
+        dist = math.hypot(ax - bx, ay - by)
+        self._cache[key] = dist
+        return dist
 
     def _get_position(self, node: SimNode) -> Tuple[float, float]:
         if isinstance(node, TransformNode):
@@ -34,6 +40,10 @@ class DistanceSystem(SystemNode):
             if isinstance(child, TransformNode):
                 return tuple(child.position)
         raise ValueError(f"Node '{node.name}' has no TransformNode")
+
+    def update(self, dt: float) -> None:  # pragma: no cover - trivial cache reset
+        self._cache.clear()
+        super().update(dt)
 
 
 register_node_type("DistanceSystem", DistanceSystem)


### PR DESCRIPTION
## Summary
- allow events to stop propagation and include timestamps
- cache distance calculations per tick
- document completed tasks and regenerate project analysis

## Testing
- `pytest`
- `flake8` *(failed: command not found / install error)*

------
https://chatgpt.com/codex/tasks/task_e_689519ea22f88330a504509ea5888b07