### PR TITLE
docs: add contributing and conduct guides

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+All contributors are expected to uphold a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+Examples of unacceptable behaviour include the use of sexual language or imagery, derogatory comments, personal attacks, and sustained disruption of discussions.
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by opening an issue or contacting the maintainers.
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contribution Guidelines
+
+Thank you for considering contributing to Nodari. To keep the project healthy and consistent, please follow these guidelines:
+
+- Use Python 3.11 and ensure new code includes type hints.
+- Run `flake8`, `mypy`, and `pytest` locally before submitting a pull request.
+- Follow the existing code style and documentation patterns.
+- Keep commits focused; isolate unrelated changes in separate commits.
+- Include relevant documentation updates and examples when introducing new features.
+
+Please also review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ python run_farm.py
 
 ## Development
 
-* Python 3.9+
+* Python 3.11+
 * Install dependencies listed in `requirements.txt`
-* Run tests with `pytest`
+* Run checks with `flake8`, `mypy` and `pytest`
+* See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines and the [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Roadmap and Tasks
 

--- a/docs/checklists/todo.md
+++ b/docs/checklists/todo.md
@@ -59,7 +59,7 @@ This checklist gathers outstanding tasks from the project specification and main
 ## Documentation & Community
 - [x] **High** Expand [project_spec.md](../specs/project_spec.md) with concrete examples for every node and system type.
 - [x] **High** Write step-by-step tutorials and how-to guides.
-- [ ] **Medium** Publish contribution guidelines and a code of conduct.
+- [x] **Medium** Publish contribution guidelines and a code of conduct.
 - [ ] **Medium** Launch a documentation website with interactive examples and API reference.
 - [ ] **Low** Organise community challenges to create and share new scenarios.
 - [ ] **Low** Auto-generated API reference using Sphinx.


### PR DESCRIPTION
## Summary
- add contribution guidelines and code of conduct
- reference new docs from README
- check off related TODO item

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68952add8a648330b2c55781f3f07b76