### PR TITLE
feat: configurable AI schedule

### DIFF
--- a/docs/specs/project_spec.md
+++ b/docs/specs/project_spec.md
@@ -163,6 +163,7 @@ Steps must be completed in order, each with accompanying unit tests.
 
 #### 4.4 AIBehaviorNode
 - Attributes: behaviour parameters (e.g., need priorities).
+- Configurable daily schedule (wake, work, lunch and sleep hours).
 - `on_event` reacts to needs, time and production events.
 - `update` may emit regular commands.
 - Tests for reacting to a need threshold by eating, etc.

--- a/tests/test_ai_behavior.py
+++ b/tests/test_ai_behavior.py
@@ -1,7 +1,10 @@
+from core.simnode import SimNode
 from nodes.ai_behavior import AIBehaviorNode
 from nodes.inventory import InventoryNode
 from nodes.need import NeedNode
 from nodes.character import CharacterNode
+from nodes.transform import TransformNode
+from systems.time import TimeSystem
 
 
 def test_ai_eats_when_hungry():
@@ -13,3 +16,16 @@ def test_ai_eats_when_hungry():
     hunger.update(1)  # value =5 -> threshold
     assert personal_inv.items.get("wheat", 0) == 1
     assert hunger.value < hunger.threshold
+
+
+def test_ai_schedule_configurable():
+    world = SimNode()
+    time = TimeSystem(start_time=22 * 3600, parent=world)
+    char = CharacterNode(name="farmer", parent=world)
+    TransformNode(parent=char, position=[0.0, 0.0])
+    ai = AIBehaviorNode(parent=char, home=char, wake_hour=5, sleep_hour=21)
+    ai._determine_target()
+    assert ai._sleeping is True
+    time.current_time = 5.5 * 3600
+    ai._determine_target()
+    assert ai._sleeping is False


### PR DESCRIPTION
## Summary
- allow AIBehaviorNode schedule and idle jitter to be defined in config
- document AI daily schedule parameters
- test that custom schedule hours affect sleeping behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895bda65740833080e536c0c66673fd