### PR TITLE
Refactor AI behavior helpers into utility module

### DIFF
--- a/nodes/ai_behavior.py
+++ b/nodes/ai_behavior.py
@@ -2,19 +2,15 @@
 from __future__ import annotations
 
 from typing import Callable, Dict, List, Optional
-import math
 import random
 
 from core.simnode import SimNode
 from core.plugins import register_node_type
 from core.units import kmh_to_mps
 from .inventory import InventoryNode
-from .need import NeedNode
 from .transform import TransformNode
-from systems.time import TimeSystem
+from . import ai_utils
 
-# Reference random speed used to scale idle jitter (2 km/h)
-_REF_RANDOM_SPEED = kmh_to_mps(2.0)
 _DEFAULT_IDLE_JITTER_DISTANCE = 0.5  # meters when random_speed is 2 km/h
 
 
@@ -105,12 +101,12 @@ class AIBehaviorNode(SimNode):
         self.on_event("need_threshold_reached", self._on_need)
         self.update_interval = update_interval
         if update_interval:
-            scheduler = self._scheduler_system()
+            scheduler = ai_utils.scheduler_system(self)
             if scheduler:
                 scheduler.schedule(self, update_interval)
 
     def update(self, dt: float) -> None:
-        transform = self._find_transform()
+        transform = ai_utils.find_transform(self.parent)
         if transform is None:
             super().update(dt)
             return
@@ -136,7 +132,7 @@ class AIBehaviorNode(SimNode):
 
     # Planning / Navigation / Economic interactions --------------------
     def plan(self, transform: TransformNode) -> Optional[List[float]]:
-        target = self._determine_target()
+        target = ai_utils.determine_target(self)
         if target is None:
             self.change_state("idle")
         else:
@@ -146,9 +142,15 @@ class AIBehaviorNode(SimNode):
     def navigate(self, transform: TransformNode, target: Optional[List[float]], dt: float) -> None:
         if target is None:
             return
-        self._move_towards(transform, target, dt)
-        if self._is_at_position(transform.position, target):
-            self._apply_idle_jitter(transform, target)
+        ai_utils.move_towards(transform, target, self.speed, dt)
+        if ai_utils.is_at_position(transform.position, target):
+            ai_utils.apply_idle_jitter(
+                transform,
+                target,
+                self.random_speed,
+                self.idle_jitter_distance,
+                self._sleeping,
+            )
             self.change_state("working")
 
     def interact(self, transform: TransformNode, target: Optional[List[float]], dt: float) -> None:
@@ -173,270 +175,49 @@ class AIBehaviorNode(SimNode):
     def _on_need(self, emitter: SimNode, event_name: str, payload) -> None:
         if payload.get("need") != "hunger":
             return
-        my_inv = self._find_inventory()
-        hunger = self._find_need("hunger")
+        my_inv = ai_utils.find_inventory(self.parent)
+        hunger = ai_utils.find_need(self.parent, "hunger")
         if my_inv is None or hunger is None or self.target_inventory is None:
             return
         if self.target_inventory.items.get("wheat", 0) > 0:
             self.target_inventory.transfer_to(my_inv, "wheat", 1)
             hunger.satisfy(50)
 
-    def _find_inventory(self) -> Optional[InventoryNode]:
-        for child in self.parent.children:
-            if isinstance(child, InventoryNode):
-                return child
-        return None
+    # Backward compatibility wrappers ---------------------------------
+    def _determine_target(self) -> Optional[List[float]]:
+        return ai_utils.determine_target(self)
 
-    def _find_need(self, name: str) -> Optional[NeedNode]:
-        for child in self.parent.children:
-            if isinstance(child, NeedNode) and child.need_name == name:
-                return child
-        return None
-
-    def _find_producer(self, node: SimNode | None) -> Optional[SimNode]:
-        if node is None:
-            return None
-        for child in node.children:
-            from .resource_producer import ResourceProducerNode
-
-            if isinstance(child, ResourceProducerNode):
-                return child
-        return None
-
-    def _find_transform(self) -> Optional[TransformNode]:
-        for child in self.parent.children:
-            if isinstance(child, TransformNode):
-                return child
-        return None
+    def _handle_work(self, transform: TransformNode, target: List[float], dt: float) -> None:
+        ai_utils.handle_work(self, transform, target, dt)
 
     # ------------------------------------------------------------------
     # Scheduling helpers
     # ------------------------------------------------------------------
-    def _root(self) -> SimNode:
-        node: SimNode = self
-        while node.parent is not None:
-            node = node.parent
-        return node
-
     def _resolve_references(self) -> None:
         if self._resolved:
             return
-        root = self._root()
+        root = ai_utils.root(self)
         if isinstance(self.home, str):
-            self.home = self._find_by_name(root, self.home)
+            self.home = ai_utils.find_by_name(root, self.home)
         if isinstance(self.work, str):
-            self.work = self._find_by_name(root, self.work)
+            self.work = ai_utils.find_by_name(root, self.work)
         if isinstance(self.home_inventory, str):
-            node = self._find_by_name(root, self.home_inventory)
+            node = ai_utils.find_by_name(root, self.home_inventory)
             if isinstance(node, InventoryNode):
                 self.home_inventory = node
         if isinstance(self.work_inventory, str):
-            node = self._find_by_name(root, self.work_inventory)
+            node = ai_utils.find_by_name(root, self.work_inventory)
             if isinstance(node, InventoryNode):
                 self.work_inventory = node
         if isinstance(self.well_inventory, str):
-            node = self._find_by_name(root, self.well_inventory)
+            node = ai_utils.find_by_name(root, self.well_inventory)
             if isinstance(node, InventoryNode):
                 self.well_inventory = node
         if isinstance(self.warehouse_inventory, str):
-            node = self._find_by_name(root, self.warehouse_inventory)
+            node = ai_utils.find_by_name(root, self.warehouse_inventory)
             if isinstance(node, InventoryNode):
                 self.warehouse_inventory = node
         self._resolved = True
-
-    def _find_by_name(self, node: SimNode, name: str) -> Optional[SimNode]:
-        if node.name == name:
-            return node
-        for child in node.children:
-            found = self._find_by_name(child, name)
-            if found is not None:
-                return found
-        return None
-
-    def _time_system(self) -> Optional[TimeSystem]:
-        root = self._root()
-        for child in self._walk(root):
-            if isinstance(child, TimeSystem):
-                return child
-        return None
-
-    def _scheduler_system(self):
-        from systems.scheduler import SchedulerSystem
-
-        root = self._root()
-        for child in self._walk(root):
-            if isinstance(child, SchedulerSystem):
-                return child
-        return None
-
-    def _walk(self, node: SimNode):  # type: ignore[override]
-        yield node
-        for child in node.children:
-            yield from self._walk(child)
-
-    def _get_position(self, node: SimNode | None) -> Optional[List[float]]:
-        if node is None:
-            return None
-        for child in node.children:
-            if isinstance(child, TransformNode):
-                return child.position
-        return None
-
-    def _determine_target(self) -> Optional[List[float]]:
-        time_sys = self._time_system()
-        if time_sys is None:
-            return None
-        t = time_sys.current_time % 86400
-        wake = self.wake_time
-        work_start = self.work_start_time
-        lunch = self.lunch_time
-        lunch_end = self.lunch_end_time
-        work_end = self.work_end_time
-        sleep = self.sleep_time
-
-        if t < wake or t >= sleep:
-            self._sleeping = True
-            self._idle = False
-            self._task = None
-            return self._get_position(self.home)
-        self._sleeping = False
-        if wake <= t < work_start:
-            self._idle = False
-            self._task = None
-            return self._get_position(self.home)
-        if work_start <= t < lunch:
-            self._idle = False
-            if self._task == "fetch_water" and isinstance(self.well_inventory, InventoryNode):
-                return self._get_position(self.well_inventory.parent)
-            if self._task == "deliver_water":
-                return self._get_position(self.work)
-            if self._task == "deliver_wheat" and isinstance(
-                self.warehouse_inventory, InventoryNode
-            ):
-                return self._get_position(self.warehouse_inventory.parent)
-            return self._get_position(self.work)
-        if lunch <= t < lunch_end:
-            if not self._idle and random.random() < self.idle_chance:
-                self._idle = True
-            return self.lunch_position
-        if lunch_end <= t < work_end:
-            self._idle = False
-            if self._task == "fetch_water" and isinstance(self.well_inventory, InventoryNode):
-                return self._get_position(self.well_inventory.parent)
-            if self._task == "deliver_water":
-                return self._get_position(self.work)
-            if self._task == "deliver_wheat" and isinstance(
-                self.warehouse_inventory, InventoryNode
-            ):
-                return self._get_position(self.warehouse_inventory.parent)
-            return self._get_position(self.work)
-        self._task = None
-        return self._get_position(self.home)
-
-    def _move_towards(self, transform: TransformNode, target: List[float], dt: float) -> None:
-        dx = target[0] - transform.position[0]
-        dy = target[1] - transform.position[1]
-        dist = math.hypot(dx, dy)
-        if dist < 1e-6:
-            return
-        step = self.speed * dt
-        if step >= dist:
-            transform.position[0], transform.position[1] = target[0], target[1]
-        else:
-            transform.position[0] += dx / dist * step
-            transform.position[1] += dy / dist * step
-
-    def _handle_work(self, transform: TransformNode, target: List[float], dt: float) -> None:
-        time_sys = self._time_system()
-        if time_sys is None:
-            return
-        t = time_sys.current_time % 86400
-        work_start = self.work_start_time
-        lunch = self.lunch_time
-        lunch_end = self.lunch_end_time
-        work_end = self.work_end_time
-        inv = self._find_inventory()
-        farm_inv = self.work_inventory if isinstance(self.work_inventory, InventoryNode) else None
-        well_inv = self.well_inventory if isinstance(self.well_inventory, InventoryNode) else None
-        warehouse_inv = self.warehouse_inventory if isinstance(self.warehouse_inventory, InventoryNode) else None
-        producer = self._find_producer(self.work)
-        if not (work_start <= t < lunch or (lunch_end <= t < work_end and not self._idle)):
-            if inv:
-                if farm_inv:
-                    amt = inv.items.get("water", 0)
-                    if amt > 0:
-                        inv.transfer_to(farm_inv, "water", amt)
-                if warehouse_inv:
-                    amt = inv.items.get("wheat", 0)
-                    if amt > 0:
-                        inv.transfer_to(warehouse_inv, "wheat", amt)
-                if (t >= work_end or t < work_start) and self.home_inventory and isinstance(self.home_inventory, InventoryNode):
-                    amt = inv.items.get("money", 0)
-                    if amt > 0:
-                        inv.transfer_to(self.home_inventory, "money", amt)
-            return
-        work_pos = self._get_position(self.work)
-        well_pos = self._get_position(well_inv.parent) if well_inv else None
-        warehouse_pos = self._get_position(warehouse_inv.parent) if warehouse_inv else None
-
-        if self._task == "fetch_water" and well_inv and well_pos and self._is_at_position(transform.position, well_pos):
-            well_producer = self._find_producer(well_inv.parent)
-            if well_producer:
-                well_producer.work(self.water_per_fetch)
-            qty = min(self.water_per_fetch, well_inv.items.get("water", 0))
-            if inv and qty > 0:
-                well_inv.transfer_to(inv, "water", qty)
-            self._task = "deliver_water"
-            return
-
-        if self._task == "deliver_water" and work_pos and self._is_at_position(transform.position, work_pos):
-            if inv and farm_inv:
-                amt = inv.items.get("water", 0)
-                if amt > 0:
-                    inv.transfer_to(farm_inv, "water", amt)
-            self._task = None
-
-        if self._task == "deliver_wheat" and warehouse_pos and self._is_at_position(transform.position, warehouse_pos):
-            if inv and warehouse_inv:
-                amt = inv.items.get("wheat", 0)
-                if amt > 0:
-                    inv.transfer_to(warehouse_inv, "wheat", amt)
-            self._task = None
-
-        if work_pos and self._is_at_position(transform.position, work_pos):
-            if inv and farm_inv:
-                if inv.items.get("water", 0) > 0:
-                    amt = inv.items.get("water", 0)
-                    inv.transfer_to(farm_inv, "water", amt)
-                if farm_inv.items.get("wheat", 0) >= self.wheat_threshold and inv.items.get("wheat", 0) == 0 and warehouse_inv:
-                    qty = farm_inv.items.get("wheat", 0)
-                    farm_inv.transfer_to(inv, "wheat", qty)
-                    self._task = "deliver_wheat"
-                    return
-                if farm_inv.items.get("water", 0) < 1 and well_inv and inv.items.get("water", 0) == 0:
-                    self._task = "fetch_water"
-                    return
-            if producer is not None and farm_inv:
-                producer.work()
-
-            self._money_acc += self.wage * dt
-            if inv is not None and self._money_acc >= 1.0:
-                amount = int(self._money_acc)
-                self._money_acc -= amount
-                inv.add_item("money", amount)
-
-    def _is_at_position(self, pos: List[float], target: List[float], threshold: float = 0.5) -> bool:
-        dx = pos[0] - target[0]
-        dy = pos[1] - target[1]
-        return math.hypot(dx, dy) <= threshold
-
-    def _apply_idle_jitter(self, transform: TransformNode, target: List[float]) -> None:
-        if self._sleeping:
-            transform.position[0], transform.position[1] = target[0], target[1]
-            return
-        jitter = (self.random_speed / _REF_RANDOM_SPEED) * self.idle_jitter_distance
-        transform.position[0] = target[0] + random.uniform(-jitter, jitter)
-        transform.position[1] = target[1] + random.uniform(-jitter, jitter)
 
 
 register_node_type("AIBehaviorNode", AIBehaviorNode)

--- a/nodes/ai_utils.py
+++ b/nodes/ai_utils.py
@@ -1,0 +1,280 @@
+"""Utility helpers for :mod:`nodes.ai_behavior`."""
+from __future__ import annotations
+
+from typing import Iterator, List, Optional, TYPE_CHECKING
+import math
+import random
+
+from core.simnode import SimNode
+from core.units import kmh_to_mps
+from .inventory import InventoryNode
+from .need import NeedNode
+from .transform import TransformNode
+from systems.time import TimeSystem
+
+if TYPE_CHECKING:  # pragma: no cover - hints only
+    from .ai_behavior import AIBehaviorNode
+    from .resource_producer import ResourceProducerNode
+
+
+# Reference random speed used to scale idle jitter (2 km/h)
+_REF_RANDOM_SPEED = kmh_to_mps(2.0)
+
+
+def root(node: SimNode) -> SimNode:
+    """Return the root of ``node``'s tree."""
+    while node.parent is not None:
+        node = node.parent
+    return node
+
+
+def walk(node: SimNode) -> Iterator[SimNode]:
+    """Yield ``node`` and all of its descendants."""
+    yield node
+    for child in node.children:
+        yield from walk(child)
+
+
+def find_by_name(node: SimNode, name: str) -> Optional[SimNode]:
+    """Find a node by ``name`` in ``node``'s subtree."""
+    if node.name == name:
+        return node
+    for child in node.children:
+        found = find_by_name(child, name)
+        if found is not None:
+            return found
+    return None
+
+
+def time_system(node: SimNode) -> Optional[TimeSystem]:
+    """Return the :class:`~systems.time.TimeSystem` attached to ``node``."""
+    r = root(node)
+    for child in walk(r):
+        if isinstance(child, TimeSystem):
+            return child
+    return None
+
+
+def scheduler_system(node: SimNode):
+    """Return the scheduler system if available."""
+    from systems.scheduler import SchedulerSystem
+
+    r = root(node)
+    for child in walk(r):
+        if isinstance(child, SchedulerSystem):
+            return child
+    return None
+
+
+def get_position(node: SimNode | None) -> Optional[List[float]]:
+    """Return the position of ``node`` if it has a transform."""
+    if node is None:
+        return None
+    for child in node.children:
+        if isinstance(child, TransformNode):
+            return child.position
+    return None
+
+
+def find_inventory(node: SimNode | None) -> Optional[InventoryNode]:
+    if node is None:
+        return None
+    for child in node.children:
+        if isinstance(child, InventoryNode):
+            return child
+    return None
+
+
+def find_need(node: SimNode | None, name: str) -> Optional[NeedNode]:
+    if node is None:
+        return None
+    for child in node.children:
+        if isinstance(child, NeedNode) and child.need_name == name:
+            return child
+    return None
+
+
+def find_producer(node: SimNode | None) -> Optional["ResourceProducerNode"]:
+    if node is None:
+        return None
+    from .resource_producer import ResourceProducerNode
+
+    for child in node.children:
+        if isinstance(child, ResourceProducerNode):
+            return child
+    return None
+
+
+def find_transform(node: SimNode | None) -> Optional[TransformNode]:
+    if node is None:
+        return None
+    for child in node.children:
+        if isinstance(child, TransformNode):
+            return child
+    return None
+
+
+def move_towards(transform: TransformNode, target: List[float], speed: float, dt: float) -> None:
+    dx = target[0] - transform.position[0]
+    dy = target[1] - transform.position[1]
+    dist = math.hypot(dx, dy)
+    if dist < 1e-6:
+        return
+    step = speed * dt
+    if step >= dist:
+        transform.position[0], transform.position[1] = target[0], target[1]
+    else:
+        transform.position[0] += dx / dist * step
+        transform.position[1] += dy / dist * step
+
+
+def is_at_position(pos: List[float], target: List[float], threshold: float = 0.5) -> bool:
+    dx = pos[0] - target[0]
+    dy = pos[1] - target[1]
+    return math.hypot(dx, dy) <= threshold
+
+
+def apply_idle_jitter(
+    transform: TransformNode,
+    target: List[float],
+    random_speed: float,
+    jitter_distance: float,
+    sleeping: bool,
+) -> None:
+    if sleeping:
+        transform.position[0], transform.position[1] = target[0], target[1]
+        return
+    jitter = (random_speed / _REF_RANDOM_SPEED) * jitter_distance
+    transform.position[0] = target[0] + random.uniform(-jitter, jitter)
+    transform.position[1] = target[1] + random.uniform(-jitter, jitter)
+
+
+def determine_target(ai: "AIBehaviorNode") -> Optional[List[float]]:
+    """Return the next target position for ``ai``."""
+    time_sys = time_system(ai)
+    if time_sys is None:
+        return None
+    t = time_sys.current_time % 86400
+    wake = ai.wake_time
+    work_start = ai.work_start_time
+    lunch = ai.lunch_time
+    lunch_end = ai.lunch_end_time
+    work_end = ai.work_end_time
+    sleep = ai.sleep_time
+
+    if t < wake or t >= sleep:
+        ai._sleeping = True
+        ai._idle = False
+        ai._task = None
+        return get_position(ai.home if isinstance(ai.home, SimNode) else None)
+    ai._sleeping = False
+    if wake <= t < work_start:
+        ai._idle = False
+        ai._task = None
+        return get_position(ai.home if isinstance(ai.home, SimNode) else None)
+    if work_start <= t < lunch:
+        ai._idle = False
+        if ai._task == "fetch_water" and isinstance(ai.well_inventory, InventoryNode):
+            return get_position(ai.well_inventory.parent)
+        if ai._task == "deliver_water":
+            return get_position(ai.work if isinstance(ai.work, SimNode) else None)
+        if ai._task == "deliver_wheat" and isinstance(ai.warehouse_inventory, InventoryNode):
+            return get_position(ai.warehouse_inventory.parent)
+        return get_position(ai.work if isinstance(ai.work, SimNode) else None)
+    if lunch <= t < lunch_end:
+        if not ai._idle and random.random() < ai.idle_chance:
+            ai._idle = True
+        return ai.lunch_position
+    if lunch_end <= t < work_end:
+        ai._idle = False
+        if ai._task == "fetch_water" and isinstance(ai.well_inventory, InventoryNode):
+            return get_position(ai.well_inventory.parent)
+        if ai._task == "deliver_water":
+            return get_position(ai.work if isinstance(ai.work, SimNode) else None)
+        if ai._task == "deliver_wheat" and isinstance(ai.warehouse_inventory, InventoryNode):
+            return get_position(ai.warehouse_inventory.parent)
+        return get_position(ai.work if isinstance(ai.work, SimNode) else None)
+    ai._task = None
+    return get_position(ai.home if isinstance(ai.home, SimNode) else None)
+
+
+def handle_work(ai: "AIBehaviorNode", transform: TransformNode, target: List[float], dt: float) -> None:
+    time_sys = time_system(ai)
+    if time_sys is None:
+        return
+    t = time_sys.current_time % 86400
+    work_start = ai.work_start_time
+    lunch = ai.lunch_time
+    lunch_end = ai.lunch_end_time
+    work_end = ai.work_end_time
+    inv = find_inventory(ai.parent)
+    farm_inv = ai.work_inventory if isinstance(ai.work_inventory, InventoryNode) else None
+    well_inv = ai.well_inventory if isinstance(ai.well_inventory, InventoryNode) else None
+    warehouse_inv = ai.warehouse_inventory if isinstance(ai.warehouse_inventory, InventoryNode) else None
+    producer = find_producer(ai.work if isinstance(ai.work, SimNode) else None)
+    if not (work_start <= t < lunch or (lunch_end <= t < work_end and not ai._idle)):
+        if inv:
+            if farm_inv:
+                amt = inv.items.get("water", 0)
+                if amt > 0:
+                    inv.transfer_to(farm_inv, "water", amt)
+            if warehouse_inv:
+                amt = inv.items.get("wheat", 0)
+                if amt > 0:
+                    inv.transfer_to(warehouse_inv, "wheat", amt)
+            if (t >= work_end or t < work_start) and ai.home_inventory and isinstance(ai.home_inventory, InventoryNode):
+                amt = inv.items.get("money", 0)
+                if amt > 0:
+                    inv.transfer_to(ai.home_inventory, "money", amt)
+        return
+    work_pos = get_position(ai.work if isinstance(ai.work, SimNode) else None)
+    well_pos = get_position(well_inv.parent) if well_inv else None
+    warehouse_pos = get_position(warehouse_inv.parent) if warehouse_inv else None
+
+    if ai._task == "fetch_water" and well_inv and well_pos and is_at_position(transform.position, well_pos):
+        well_producer = find_producer(well_inv.parent)
+        if well_producer:
+            well_producer.work(ai.water_per_fetch)
+        qty = min(ai.water_per_fetch, well_inv.items.get("water", 0))
+        if inv and qty > 0:
+            well_inv.transfer_to(inv, "water", qty)
+        ai._task = "deliver_water"
+        return
+
+    if ai._task == "deliver_water" and work_pos and is_at_position(transform.position, work_pos):
+        if inv and farm_inv:
+            amt = inv.items.get("water", 0)
+            if amt > 0:
+                inv.transfer_to(farm_inv, "water", amt)
+        ai._task = None
+
+    if ai._task == "deliver_wheat" and warehouse_pos and is_at_position(transform.position, warehouse_pos):
+        if inv and warehouse_inv:
+            amt = inv.items.get("wheat", 0)
+            if amt > 0:
+                inv.transfer_to(warehouse_inv, "wheat", amt)
+        ai._task = None
+
+    if work_pos and is_at_position(transform.position, work_pos):
+        if inv and farm_inv:
+            if inv.items.get("water", 0) > 0:
+                amt = inv.items.get("water", 0)
+                inv.transfer_to(farm_inv, "water", amt)
+            if farm_inv.items.get("wheat", 0) >= ai.wheat_threshold and inv.items.get("wheat", 0) == 0 and warehouse_inv:
+                qty = farm_inv.items.get("wheat", 0)
+                farm_inv.transfer_to(inv, "wheat", qty)
+                ai._task = "deliver_wheat"
+                return
+            if farm_inv.items.get("water", 0) < 1 and well_inv and inv.items.get("water", 0) == 0:
+                ai._task = "fetch_water"
+                return
+        if producer is not None and farm_inv:
+            producer.work()
+
+        ai._money_acc += ai.wage * dt
+        if inv is not None and ai._money_acc >= 1.0:
+            amount = int(ai._money_acc)
+            ai._money_acc -= amount
+            inv.add_item("money", amount)
+
+


### PR DESCRIPTION
## Summary
- factor out tree navigation, scheduling, and movement helpers into `ai_utils`
- simplify `AIBehaviorNode` by delegating planning and work logic to the utility module while keeping backward-compatible wrappers

## Testing
- `pytest`
- `mypy nodes/ai_utils.py nodes/ai_behavior.py`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*


------
https://chatgpt.com/codex/tasks/task_e_6895c667f3308330bb6e128a9fadac95