### PR TITLE
ci: run only on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- avoid CI emails after merge by running workflow only on pull requests
- allow manual workflow dispatch

## Testing
- `pytest`
- `flake8` *(command not found)*
- `mypy .` *(errors: Item "None" of "SimNode | None" has no attribute "add_child"; Invalid index type "tuple[int, ...]" for "dict[tuple[int, int], float]"; Invalid index type "tuple[int, ...]" for "dict[tuple[int, int], float]"; Incompatible return value type (got "tuple[float, ...]", expected "tuple[float, float]"); Incompatible return value type (got "tuple[float, ...]", expected "tuple[float, float]")*

------
https://chatgpt.com/codex/tasks/task_e_6895ccc8dae4833087ae6df4c9218957