### PR TITLE
Improve viewer layout and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ All map coordinates, distances and speeds in the simulation use meters as the
 base unit. Velocities are expressed in meters per second. Utility conversion
 helpers (kilometres, km/h, square kilometres…) live in `core/units.py`.
 
-The example runner scales simulation time by a factor of 12 (one simulated day
-equals two real hours) so characters cover the roughly 100 m between houses at
-a walking pace.
+Runtime parameters such as time scaling, initial time and display sizes are
+centralised in `config.py`. By default the simulation advances one simulated
+minute per real second and starts at 07:30.
 
 ## Running the simulation
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,12 @@
+"""Central configuration for the farm simulation."""
+
+# Display settings
+VIEW_WIDTH = 1200
+VIEW_HEIGHT = 720
+PANEL_WIDTH = 220
+FONT_SIZE = 18
+
+# Simulation timing
+FPS = 24
+TIME_SCALE = 60  # one simulated minute per real second
+START_TIME = 7 * 3600 + 30 * 60  # 07:30 in seconds

--- a/example_farm.json
+++ b/example_farm.json
@@ -123,11 +123,11 @@
           {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "lunch_position": [120, 80], "speed": 5, "random_speed": 2, "idle_chance": 0.2}}
         ]
       },
-      {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60, "start_time": 14400}},
+      {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60}},
       {"type": "EconomySystem", "id": "economy"},
       {"type": "LoggingSystem", "id": "logger"},
       {"type": "DistanceSystem", "id": "distance"},
-      {"type": "PygameViewerSystem", "id": "viewer", "config": {"width": 1200, "height": 720, "scale": 5}}
+      {"type": "PygameViewerSystem", "id": "viewer", "config": {"scale": 5}}
     ]
   }
 }

--- a/run_farm.py
+++ b/run_farm.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import pygame
 
+import config
+
 from core.loader import load_simulation_from_file
 from core.plugins import load_plugins
 from nodes.ai_behavior import AIBehaviorNode
 from nodes.inventory import InventoryNode
 from nodes.resource_producer import ResourceProducerNode
 from systems.pygame_viewer import PygameViewerSystem
+from systems.time import TimeSystem
 
 
 # Charge tous les plugins nécessaires pour la simulation
@@ -65,9 +68,13 @@ _link_producers(world)
 if not any(isinstance(c, PygameViewerSystem) for c in world.children):
     PygameViewerSystem(parent=world)
 
+time_system = next((c for c in world.children if isinstance(c, TimeSystem)), None)
+if time_system is not None:
+    time_system.current_time = config.START_TIME
 
-FPS = 24
-TIME_SCALE = 86400 / 50  # 1 journée simulée = 2 heures réelles
+
+FPS = config.FPS
+TIME_SCALE = config.TIME_SCALE
 
 clock = pygame.time.Clock()
 

--- a/tests/test_pygame_viewer.py
+++ b/tests/test_pygame_viewer.py
@@ -13,7 +13,7 @@ def test_pygame_viewer_runs():
     os.environ["SDL_VIDEODRIVER"] = "dummy"
     world = WorldNode(name="world")
     InventoryNode(name="inv", items={"wheat": 1}, parent=world)
-    viewer = PygameViewerSystem(parent=world, width=120, height=80)
+    viewer = PygameViewerSystem(parent=world, width=120, height=80, panel_width=30)
     world.update(0)
-    assert viewer.screen.get_size() == (120, 80)
+    assert viewer.screen.get_size() == (150, 80)
     pygame.quit()


### PR DESCRIPTION
## Summary
- add central `config.py` for display and timing settings
- expand Pygame viewer with side panel and clearer info
- start simulation at 07:30 and slow down time scale

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8 mypy` *(fails: Could not find a version that satisfies the requirement flake8)*
- `mypy .` *(fails: Item "None" of "SimNode | None" has no attribute "add_child")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fc517d3c8330aa9a8b3155ca39c2