### PR TITLE
Add basic AnimalNode and documentation

### DIFF
--- a/docs/specs/animal_nodes.md
+++ b/docs/specs/animal_nodes.md
@@ -1,0 +1,11 @@
+# Animal Nodes
+
+Introducing animals into the simulation requires a dedicated `AnimalNode` type that composes existing building blocks:
+
+- **Needs** – animals often require hunger or fatigue tracking. These can reuse `NeedNode` instances attached as children.
+- **Resource production** – livestock like cows or chickens may produce milk or eggs through a `ResourceProducerNode`.
+- **Events** – actions such as feeding or harvesting emit events (`animal_fed`, `resource_produced`) for systems to react.
+- **Hierarchy** – animals live within the node tree like any other entity. They can be attached to a `FarmNode` or directly to the world root.
+- **Reproduction** – reproduction logic can be added later via additional nodes or systems.
+
+The new `AnimalNode` class establishes a foundation for these behaviours, enabling future expansion without altering existing nodes.

--- a/docs/specs/project_spec.md
+++ b/docs/specs/project_spec.md
@@ -55,6 +55,7 @@ For modelling the farm and inhabitants:
 - **ResourceProducerNode** – produces a resource every tick consuming optional inputs. Emits `resource_produced`.
 - **AIBehaviorNode** – decides actions based on internal state and events (`need_threshold_reached`, `phase_changed`, etc.).
 - **TransformNode** (optional) – stores position in meters and velocity in meters per second.
+- **AnimalNode** – represents livestock or wildlife with needs and optional resource production. Emits events such as `animal_fed`.
 
 Example usage:
 
@@ -64,10 +65,12 @@ from nodes.need import NeedNode
 from nodes.resource_producer import ResourceProducerNode
 from nodes.ai_behavior import AIBehaviorNode
 from nodes.transform import TransformNode
+from nodes.animal import AnimalNode
 
 inv = InventoryNode(items={"wheat": 10})
 hunger = NeedNode(need_name="hunger", threshold=50, increase_rate=1)
 producer = ResourceProducerNode(resource="wheat")
+animal = AnimalNode(species="cow", hunger=hunger, producer=producer)
 ai = AIBehaviorNode()
 transform = TransformNode(position=[0, 0])
 ```

--- a/nodes/animal.py
+++ b/nodes/animal.py
@@ -1,0 +1,36 @@
+"""Node representing an animal with basic hunger handling."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+from .need import NeedNode
+from .resource_producer import ResourceProducerNode
+
+
+class AnimalNode(SimNode):
+    """Represents an animal with optional needs and resource production."""
+
+    def __init__(
+        self,
+        species: str,
+        hunger: NeedNode | None = None,
+        producer: ResourceProducerNode | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.species = species
+        if hunger:
+            hunger.parent = self
+        if producer:
+            producer.parent = self
+
+    def feed(self, amount: float) -> None:
+        """Satisfy the hunger need if present."""
+        for child in self.children:
+            if isinstance(child, NeedNode) and child.need_name == "hunger":
+                child.satisfy(amount)
+                self.emit("animal_fed", {"species": self.species, "amount": amount})
+                break
+
+
+register_node_type("AnimalNode", AnimalNode)


### PR DESCRIPTION
## Summary
- introduce `AnimalNode` for livestock or wildlife with optional hunger and resource production
- document animal integration and list `AnimalNode` among generic nodes
- outline design considerations for animal nodes

## Testing
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: Item "None" of "SimNode | None" has no attribute "add_child"; systems type errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689656caaecc833096f1ade1648ca952