### PR TITLE
docs: expand node reference

### DIFF
--- a/docs/specs/node_reference.md
+++ b/docs/specs/node_reference.md
@@ -1,19 +1,87 @@
 # Node Reference
 
-Brief overview of available nodes in the simulation.
+Detailed description of the simulation nodes. Each section outlines the
+purpose of the node, notable attributes and how it interacts with other
+components in the world tree.
 
-- **AnimalNode** – represents an animal with optional needs and resource production.
-- **BarnNode** – simple building used to shelter animals and equipment.
-- **CharacterNode** – composite node representing a farmer.
-- **FarmNode** – central farm container with inventories and producers.
-- **HouseNode** – dwelling where characters live and store resources.
-- **InventoryNode** – holds quantities of items and supports transfers.
-- **NeedNode** – models a consumable need such as hunger.
-- **PastureNode** – open grazing area for animals.
-- **ResourceProducerNode** – produces resources over time or when activated.
-- **SiloNode** – tall structure for storing harvested crops.
-- **TransformNode** – stores position and velocity in metres.
-- **WarehouseNode** – storage building for goods.
-- **WellNode** – produces water for use in the farm.
-- **WorldNode** – root node containing the entire simulation.
-- **AIBehaviorNode** – minimal behaviour controller for characters.
+## AnimalNode
+
+Represents an individual animal. An animal may have child
+`NeedNode` instances (e.g. hunger) and optionally a
+`ResourceProducerNode` to model milk, eggs, etc. Feeding an
+animal satisfies the hunger need and emits an `animal_fed` event.
+
+## BarnNode
+
+Simple container used to shelter animals or store equipment. The barn has
+no special behaviour of its own but groups related nodes in the tree.
+
+## CharacterNode
+
+Composite node representing a farmer or other NPC. Characters typically
+contain a `TransformNode` for position, an `AIBehaviorNode` for simple
+behaviour and an `InventoryNode` for personal items.
+
+## FarmNode
+
+Central node representing a farm. It usually owns various buildings,
+inventories and resource producers that belong to the same farmstead.
+
+## HouseNode
+
+Dwelling where characters live and store resources. Houses often contain
+an `InventoryNode` to hold goods owned by the inhabitants.
+
+## InventoryNode
+
+Maintains a dictionary of item quantities. Provides `add_item`,
+`remove_item` and `transfer_to` helpers and emits an `inventory_changed`
+event whenever the stock is modified.
+
+## NeedNode
+
+Models a consumable need such as hunger or fatigue. The need value
+increases over time until it crosses a threshold, at which point a
+`need_threshold_reached` event is emitted. Satisfying the need lowers the
+value and can trigger `need_satisfied`.
+
+## PastureNode
+
+Open grazing area for animals. Used primarily as a location within the
+world tree.
+
+## ResourceProducerNode
+
+Produces a named resource either automatically every tick or when the
+`work` method is called. Inputs can be configured so production consumes
+other resources. Successful production emits a `resource_produced` event.
+
+## SiloNode
+
+Tall structure used to store harvested crops. The optional `capacity`
+attribute can limit how much grain the silo may hold.
+
+## TransformNode
+
+Stores 2D position and velocity in metres and metres per second. During
+each update the position is advanced according to the velocity.
+
+## WarehouseNode
+
+Generic storage building used for goods that do not belong in the silo or
+house.
+
+## WellNode
+
+Node representing a simple well where characters can collect water.
+
+## WorldNode
+
+Root of the simulation tree. Tracks the overall world size and optional
+random seed used to make simulations deterministic.
+
+## AIBehaviorNode
+
+Light‑weight behaviour controller for characters. It handles navigation,
+basic daily routines and interactions with inventories and needs such as
+fetching water or eating when hungry.


### PR DESCRIPTION
## Summary
- document each simulation node with dedicated sections
- explain attributes and interactions for behaviour and resource management

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897612a321883308dd681f92d8455e0