### PR TITLE
feat: modular AI routines

### DIFF
--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -19,6 +19,8 @@ from nodes.character import CharacterNode
 from nodes.ai_behavior import AIBehaviorNode
 
 char = CharacterNode(name="farmer", parent=root)
+# by default the AI uses ``FarmerRoutine`` but any routine class can be
+# provided via the ``routine`` argument
 AIBehaviorNode(parent=char)
 ```
 

--- a/docs/guides/run_mode.md
+++ b/docs/guides/run_mode.md
@@ -94,7 +94,7 @@ sequenceDiagram
 ```
 
 - `NeedNode` augmente sa valeur et déclenche `need_threshold_reached` quand un seuil est atteint.
-- `AIBehaviorNode` écoute cet événement pour transférer des ressources depuis un inventaire cible et appelle `satisfy` sur le besoin.
+- `AIBehaviorNode` (via sa routine) écoute cet événement pour transférer des ressources depuis un inventaire cible et appelle `satisfy` sur le besoin.
 
 ### 3.3 Échanges économiques
 

--- a/docs/specs/node_reference.md
+++ b/docs/specs/node_reference.md
@@ -82,6 +82,10 @@ random seed used to make simulations deterministic.
 
 ## AIBehaviorNode
 
-Light‑weight behaviour controller for characters. It handles navigation,
-basic daily routines and interactions with inventories and needs such as
-fetching water or eating when hungry.
+Light‑weight behaviour controller for characters. The node delegates its
+logic to a pluggable *routine* class, allowing different behaviours to be
+swapped without modifying the core engine. The default
+`FarmerRoutine` handles navigation, daily schedules and interactions with
+inventories (fetching water, eating when hungry, delivering goods). Other
+routines can be referenced in configuration files via their dotted class
+path.

--- a/example_expanded_farm.json
+++ b/example_expanded_farm.json
@@ -54,7 +54,7 @@
         "children": [
           {"type": "TransformNode", "config": {"position": [10, 10]}},
           {"type": "InventoryNode", "id": "farmer_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "farm", "work": "farm", "home_inventory": "farm_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "farm", "field_inventory": "farm_inventory", "lunch_position": [50, 50], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "farm", "work": "farm", "home_inventory": "farm_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "farm", "field_inventory": "farm_inventory", "lunch_position": [50, 50], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       }
     ]

--- a/example_farm.json
+++ b/example_farm.json
@@ -63,70 +63,70 @@
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "id": "jean_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "marie", "config": {"gender": "female"},
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "id": "marie_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house1", "work": "farm", "home_inventory": "house1_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "pierre", "config": {"gender": "male"},
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 120]}},
           {"type": "InventoryNode", "id": "pierre_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "julie", "config": {"gender": "female"},
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 120]}},
           {"type": "InventoryNode", "id": "julie_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house2", "work": "farm", "home_inventory": "house2_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "paul", "config": {"gender": "male"},
         "children": [
           {"type": "TransformNode", "config": {"position": [120, 20]}},
           {"type": "InventoryNode", "id": "paul_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "claire", "config": {"gender": "female"},
         "children": [
           {"type": "TransformNode", "config": {"position": [120, 20]}},
           {"type": "InventoryNode", "id": "claire_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house3", "work": "farm", "home_inventory": "house3_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "jacques", "config": {"gender": "male"},
         "children": [
           {"type": "TransformNode", "config": {"position": [220, 40]}},
           {"type": "InventoryNode", "id": "jacques_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "sophie", "config": {"gender": "female"},
         "children": [
           {"type": "TransformNode", "config": {"position": [220, 40]}},
           {"type": "InventoryNode", "id": "sophie_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house4", "work": "farm", "home_inventory": "house4_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "louis", "config": {"gender": "male"},
         "children": [
           {"type": "TransformNode", "config": {"position": [200, 120]}},
           {"type": "InventoryNode", "id": "louis_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "CharacterNode", "id": "anne", "config": {"gender": "female"},
         "children": [
           {"type": "TransformNode", "config": {"position": [200, 120]}},
           {"type": "InventoryNode", "id": "anne_inventory", "config": {"items": {}}},
-          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2}}
+          {"type": "AIBehaviorNode", "config": {"home": "house5", "work": "farm", "home_inventory": "house5_inventory", "work_inventory": "farm_inventory", "well_inventory": "well_inventory", "warehouse_inventory": "warehouse_inventory", "field": "field", "field_inventory": "field_inventory", "lunch_position": [120, 80], "idle_chance": 0.2, "routine": "nodes.routines.farmer.FarmerRoutine"}}
         ]
       },
       {"type": "TimeSystem", "id": "time", "config": {"tick_duration": 60}},

--- a/nodes/routines/__init__.py
+++ b/nodes/routines/__init__.py
@@ -1,0 +1,1 @@
+"""Behavior routines for AIBehaviorNode."""

--- a/nodes/routines/base.py
+++ b/nodes/routines/base.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from nodes.transform import TransformNode
+    from nodes.ai_behavior import AIBehaviorNode
+
+
+class BaseRoutine(ABC):
+    """Interface for character behaviour routines.
+
+    A routine encapsulates planning, navigation and interactions for an
+    :class:`~nodes.ai_behavior.AIBehaviorNode`.
+    """
+
+    def __init__(self, ai: AIBehaviorNode) -> None:
+        self.ai = ai
+
+    def on_need(self, emitter, event_name: str, payload) -> None:  # pragma: no cover - optional
+        """Handle need events (default: no-op)."""
+        return None
+
+    @abstractmethod
+    def update(self, dt: float, transform: TransformNode) -> None:
+        """Update behaviour for the character."""
+        raise NotImplementedError

--- a/nodes/routines/farmer.py
+++ b/nodes/routines/farmer.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import random
+from typing import Callable, Dict, List, Optional
+
+from .base import BaseRoutine
+from .. import ai_utils
+from ..transform import TransformNode
+
+
+class FarmerRoutine(BaseRoutine):
+    """Default farmer behaviour used by :class:`AIBehaviorNode`."""
+
+    def __init__(self, ai: "AIBehaviorNode") -> None:
+        super().__init__(ai)
+        self.state_handlers: Dict[str, Callable[[float, TransformNode], None]] = {
+            "idle": self._state_idle,
+            "moving": self._state_moving,
+            "working": self._state_working,
+        }
+
+    # ------------------------------------------------------------------
+    # Main routine API
+    # ------------------------------------------------------------------
+    def update(self, dt: float, transform: TransformNode) -> None:
+        ai = self.ai
+        if ai.home or ai.work:
+            ai.resolve_references()
+            target = self.plan(transform)
+            self.navigate(transform, target, dt)
+            self.interact(transform, target, dt)
+        else:
+            # fallback random walk when no home/work defined
+            transform.position[0] += random.uniform(-1, 1) * ai.random_speed * dt
+            transform.position[1] += random.uniform(-1, 1) * ai.random_speed * dt
+
+    def on_need(self, emitter, event_name: str, payload) -> None:
+        if payload.get("need") != "hunger":
+            return
+        my_inv = ai_utils.find_inventory(self.ai.parent)
+        hunger = ai_utils.find_need(self.ai.parent, "hunger")
+        if my_inv is None or hunger is None or self.ai.target_inventory is None:
+            return
+        if self.ai.target_inventory.items.get("wheat", 0) > 0:
+            self.ai.target_inventory.transfer_to(my_inv, "wheat", 1)
+            hunger.satisfy(50)
+
+    # ------------------------------------------------------------------
+    # Planning / Navigation / Interactions
+    # ------------------------------------------------------------------
+    def plan(self, transform: TransformNode) -> Optional[List[float]]:
+        target = ai_utils.determine_target(self.ai)
+        if target is None:
+            self.ai.change_state("idle")
+        else:
+            self.ai.change_state("moving")
+        return target
+
+    def navigate(self, transform: TransformNode, target: Optional[List[float]], dt: float) -> None:
+        if target is None:
+            return
+        ai_utils.move_towards(transform, target, self.ai.speed, dt)
+        if ai_utils.is_at_position(transform.position, target):
+            ai_utils.apply_idle_jitter(
+                transform,
+                target,
+                self.ai.random_speed,
+                self.ai.idle_jitter_distance,
+                self.ai._sleeping,
+            )
+            self.ai.change_state("working")
+
+    def interact(self, transform: TransformNode, target: Optional[List[float]], dt: float) -> None:
+        if target is None:
+            return
+        handler = self.state_handlers.get(self.ai.state)
+        if handler:
+            handler(dt, transform)
+
+    # ------------------------------------------------------------------
+    # State handlers
+    # ------------------------------------------------------------------
+    def _state_idle(self, dt: float, transform: TransformNode) -> None:  # pragma: no cover - trivial
+        pass
+
+    def _state_moving(self, dt: float, transform: TransformNode) -> None:  # pragma: no cover - handled in navigate
+        pass
+
+    def _state_working(self, dt: float, transform: TransformNode) -> None:
+        target = self._determine_target()
+        if target is not None:
+            self._handle_work(transform, target, dt)
+
+    # ------------------------------------------------------------------
+    # Internal helpers mirroring previous AIBehaviorNode methods
+    # ------------------------------------------------------------------
+    def _determine_target(self) -> Optional[List[float]]:
+        return ai_utils.determine_target(self.ai)
+
+    def _handle_work(self, transform: TransformNode, target: List[float], dt: float) -> None:
+        ai_utils.handle_work(self.ai, transform, target, dt)

--- a/tests/test_ai_behavior.py
+++ b/tests/test_ai_behavior.py
@@ -5,6 +5,13 @@ from nodes.need import NeedNode
 from nodes.character import CharacterNode
 from nodes.transform import TransformNode
 from systems.time import TimeSystem
+from nodes.routines.base import BaseRoutine
+
+
+class DummyRoutine(BaseRoutine):
+    def update(self, dt, transform):
+        self.ai.change_state("custom")
+
 
 
 def test_ai_eats_when_hungry():
@@ -29,3 +36,22 @@ def test_ai_schedule_configurable():
     time.current_time = 5.5 * 3600
     ai._determine_target()
     assert ai._sleeping is False
+
+
+def test_ai_custom_routine_class():
+    world = SimNode()
+    char = CharacterNode(name="farmer", parent=world)
+    TransformNode(parent=char, position=[0.0, 0.0])
+    ai = AIBehaviorNode(parent=char, routine=DummyRoutine)
+    ai.update(1.0)
+    assert ai.state == "custom"
+
+
+def test_ai_custom_routine_path():
+    world = SimNode()
+    char = CharacterNode(name="farmer", parent=world)
+    TransformNode(parent=char, position=[0.0, 0.0])
+    path = "tests.test_ai_behavior.DummyRoutine"
+    ai = AIBehaviorNode(parent=char, routine=path)
+    ai.update(1.0)
+    assert ai.state == "custom"


### PR DESCRIPTION
## Summary
- add routine interface and FarmerRoutine implementation for character AI
- load routines dynamically in AIBehaviorNode and expose routine selector in configs
- document and test routine plugin system

## Testing
- `pytest`
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68984f2286ec833091fd12d2eaa717f0