### PR TITLE
Improve viewer panel layout and sizing

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,8 +3,8 @@
 # Display settings
 VIEW_WIDTH = 1200
 VIEW_HEIGHT = 720
-PANEL_WIDTH = 220
-FONT_SIZE = 18
+PANEL_WIDTH = 320
+FONT_SIZE = 14
 
 # Simulation timing
 FPS = 24

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -129,13 +129,15 @@ class PygameViewerSystem(SystemNode):
         for attr, value in vars(node).items():
             if attr.startswith("_") or attr in {"parent", "children"}:
                 continue
-            lines.append(f"{attr}: {value}")
+            lines.append(f"{attr}:")
+            lines.append(f"  {value}")
         for child in node.children:
             lines.append(child.__class__.__name__ + ":")
             for attr, value in vars(child).items():
                 if attr.startswith("_") or attr in {"parent", "children"}:
                     continue
-                lines.append(f"  {attr}: {value}")
+                lines.append(f"  {attr}:")
+                lines.append(f"    {value}")
         return lines
 
     def update(self, dt: float) -> None:  # noqa: D401 - inherit docstring


### PR DESCRIPTION
## Summary
- widen pygame info panel and reduce default font size
- show attribute keys and values on separate lines in viewer panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b99e6eb483309cbb84295edd4af2