### PR TITLE
Refine CI workflow with separate installs and SDL dummy driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt flake8 mypy
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - run: pip install flake8 mypy pygame-stubs
       - run: flake8 .
-      - run: mypy .
+      - run: mypy --ignore-missing-imports .
+        env: { SDL_VIDEODRIVER: dummy }
       - run: pytest
+        env: { SDL_VIDEODRIVER: dummy }


### PR DESCRIPTION
## Summary
- split requirements and lint/type-stub installs in CI
- use SDL_VIDEODRIVER=dummy for mypy and pytest
- enable pip caching in setup-python
- run mypy with --ignore-missing-imports

## Testing
- `pip install -r requirements.txt flake8 mypy pygame-stubs` *(failed: No matching distribution found for flake8)*
- `flake8` *(command not found)*
- `mypy --ignore-missing-imports .` *(errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898eb0c704883309fac1a4c4cf88712