### PR TITLE
Centralize map editor dimensions in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ All map coordinates, distances and speeds in the simulation use meters as the
 base unit. Velocities are expressed in meters per second. Utility conversion
 helpers (kilometres, km/h, square kilometres…) live in `core/units.py`.
 
-Runtime parameters such as time scaling, initial time and display sizes are
-centralised in `config.py`. By default the simulation advances one simulated
-minute per real second and starts at 07:30.
+Runtime parameters such as time scaling, initial time, display sizes and map
+dimensions are centralised in `config.py`. By default the simulation advances
+one simulated minute per real second and starts at 07:30.
 
 ## Running the simulation
 
@@ -39,6 +39,8 @@ python tools/map_editor.py [output.json]
 Use the mouse to draw buildings and the number keys `1`–`6` to switch between
 building types. The current map is automatically exported when the window is
 closed, or you can press `E` to export manually to the chosen JSON file.
+The editor's pixel scale and world size can be adjusted via `SCALE`,
+`WORLD_WIDTH` and `WORLD_HEIGHT` in `config.py`.
 
 ## Development
 

--- a/config.py
+++ b/config.py
@@ -6,6 +6,11 @@ VIEW_HEIGHT = 720
 PANEL_WIDTH = 320
 FONT_SIZE = 14
 
+# Map editor defaults
+SCALE = 5
+WORLD_WIDTH = 240
+WORLD_HEIGHT = 144
+
 # Simulation timing
 FPS = 24
 TIME_SCALE = 600  # one simulated minute per real second

--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -19,13 +19,13 @@ if str(ROOT) not in sys.path:
 
 try:  # pragma: no cover - import guard
     import config  # type: ignore
-    PANEL_WIDTH = getattr(config, "PANEL_WIDTH", 320)
-    FONT_SIZE = getattr(config, "FONT_SIZE", 14)
 except Exception:  # pragma: no cover - fall back to defaults
-    PANEL_WIDTH = 320
-    FONT_SIZE = 14
-
-import config
+    class config:  # type: ignore
+        PANEL_WIDTH = 320
+        FONT_SIZE = 14
+        SCALE = 5
+        WORLD_WIDTH = 240
+        WORLD_HEIGHT = 144
 
 
 # Use a dummy video driver only when running on a headless Linux system.
@@ -44,13 +44,11 @@ if (
 
 pygame.init()
 
-SCALE = 5
-WORLD_WIDTH = 240
-WORLD_HEIGHT = 144
+SCALE = config.SCALE
+WORLD_WIDTH = config.WORLD_WIDTH
+WORLD_HEIGHT = config.WORLD_HEIGHT
 VIEW_WIDTH = WORLD_WIDTH * SCALE
 VIEW_HEIGHT = WORLD_HEIGHT * SCALE
-
-FONT = pygame.font.Font(None, FONT_SIZE)
 
 PANEL_WIDTH = config.PANEL_WIDTH
 FONT = pygame.font.Font(None, config.FONT_SIZE)


### PR DESCRIPTION
## Summary
- add default SCALE, WORLD_WIDTH, and WORLD_HEIGHT constants to `config.py`
- use configuration values in the map editor instead of hardcoded constants
- document map dimension settings in `README.md`

## Testing
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: type errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f123ef048330b92cbee6de329a50