### PR TITLE
Handle pygame init gracefully in farm runner

### DIFF
--- a/run_farm.py
+++ b/run_farm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pygame
@@ -17,6 +18,17 @@ from nodes.character import CharacterNode
 from nodes.house import HouseNode
 from systems.pygame_viewer import PygameViewerSystem
 from systems.time import TimeSystem
+
+
+# Ensure pygame can be used even when no display is available
+if "DISPLAY" not in os.environ and os.environ.get("SDL_VIDEODRIVER") is None:
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+
+try:
+    pygame.init()
+except pygame.error as exc:  # pragma: no cover - environment-specific
+    print(f"Unable to initialize pygame: {exc}")
+    sys.exit(1)
 
 
 # Charge tous les plugins nécessaires pour la simulation


### PR DESCRIPTION
## Summary
- ensure run_farm.py imports sys and pygame at the top
- initialize pygame with a fallback to a dummy display when no display is present

## Testing
- `python run_farm.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898f95d40408330999c7e48cecbd53f