### PR TITLE
Add building type selection to map editor

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,3 +19,16 @@ This directory contains guides, specifications, checklists and prompts for the N
 - [Select a task](prompts/task_selection.md)
 
 Additional images live in the [images](images) folder.
+
+## Map editor key bindings
+
+The map editor (`tools/map_editor.py`) supports placing various building types. Use the number keys to select the current building:
+
+- `1` – `HouseNode` (default)
+- `2` – `BarnNode`
+- `3` – `SiloNode`
+- `4` – `PastureNode`
+- `5` – `WellNode`
+- `6` – `WarehouseNode`
+
+Press `E` to export the current map to JSON.

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -22,3 +22,34 @@ def test_load_json(tmp_path: Path):
     assert isinstance(root, WorldNode)
     assert isinstance(root.children[0], InventoryNode)
     assert root.children[0].items["wheat"] == 1
+
+
+def test_map_editor_export_types(tmp_path: Path):
+    import pygame
+    from tools.map_editor import export
+    from nodes.barn import BarnNode
+    from nodes.house import HouseNode
+    from nodes.pasture import PastureNode
+    from nodes.silo import SiloNode
+    from nodes.warehouse import WarehouseNode
+    from nodes.well import WellNode
+    from nodes.transform import TransformNode  # noqa: F401
+
+    types = [
+        ("HouseNode", HouseNode),
+        ("BarnNode", BarnNode),
+        ("SiloNode", SiloNode),
+        ("PastureNode", PastureNode),
+        ("WellNode", WellNode),
+        ("WarehouseNode", WarehouseNode),
+    ]
+    buildings = []
+    for i, (name, _) in enumerate(types):
+        rect = pygame.Rect(i * 10, 0, 10, 10)
+        buildings.append((rect, name))
+    path = tmp_path / "map.json"
+    export(buildings, path)
+    root = load_simulation_from_file(str(path))
+    assert isinstance(root, WorldNode)
+    for node, (_, cls) in zip(root.children, types):
+        assert isinstance(node, cls)


### PR DESCRIPTION
## Summary
- Add keyboard mapping for selecting building types in map editor and export chosen type with transform
- Document map editor key bindings and supported building nodes
- Test loading exported maps to ensure correct node types

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68990444af98833093cf96d0a5dd0396