### PR TITLE
Add optional position to building nodes

### DIFF
--- a/example_all_nodes.json
+++ b/example_all_nodes.json
@@ -3,19 +3,19 @@
     "type": "WorldNode",
     "config": {"width": 240, "height": 144, "seed": 42},
     "children": [
-      {"type": "HouseNode", "id": "house1", "config": {"width": 40, "height": 40},
+      {"type": "HouseNode", "id": "house1", "config": {"width": 40, "height": 40, "position": [20, 20]},
         "children": [
           {"type": "TransformNode", "config": {"position": [20, 20]}},
           {"type": "InventoryNode", "id": "house1_inventory", "config": {"items": {}}}
         ]
       },
-      {"type": "BarnNode", "id": "barn", "config": {"width": 60, "height": 30},
+      {"type": "BarnNode", "id": "barn", "config": {"width": 60, "height": 30, "position": [80, 40]},
         "children": [
           {"type": "TransformNode", "config": {"position": [80, 40]}},
           {"type": "InventoryNode", "id": "barn_inventory", "config": {"items": {}}}
         ]
       },
-      {"type": "PastureNode", "id": "pasture", "config": {"width": 80, "height": 80},
+      {"type": "PastureNode", "id": "pasture", "config": {"width": 80, "height": 80, "position": [120, 100]},
         "children": [
           {"type": "TransformNode", "config": {"position": [120, 100]}},
           {"type": "AnimalNode", "id": "cow1", "config": {"species": "cow"},
@@ -26,7 +26,7 @@
           }
         ]
       },
-      {"type": "SiloNode", "id": "silo", "config": {"width": 20, "height": 40},
+      {"type": "SiloNode", "id": "silo", "config": {"width": 20, "height": 40, "position": [160, 40]},
         "children": [
           {"type": "TransformNode", "config": {"position": [160, 40]}},
           {"type": "InventoryNode", "id": "silo_inventory", "config": {"items": {}}}
@@ -39,14 +39,14 @@
           {"type": "ResourceProducerNode", "id": "field_producer", "config": {"resource": "wheat", "rate_per_tick": 1, "inputs": {"water": 1}}}
         ]
       },
-      {"type": "WellNode", "id": "well",
+      {"type": "WellNode", "id": "well", "config": {"position": [40, 70]},
         "children": [
           {"type": "TransformNode", "config": {"position": [40, 70]}},
           {"type": "InventoryNode", "id": "well_inventory", "config": {"items": {"water": 0}}},
           {"type": "ResourceProducerNode", "id": "well_producer", "config": {"resource": "water", "rate_per_tick": 1, "auto": false}}
         ]
       },
-      {"type": "WarehouseNode", "id": "warehouse", "config": {"width": 50, "height": 30},
+      {"type": "WarehouseNode", "id": "warehouse", "config": {"width": 50, "height": 30, "position": [200, 70]},
         "children": [
           {"type": "TransformNode", "config": {"position": [200, 70]}},
           {"type": "InventoryNode", "id": "warehouse_inventory", "config": {"items": {}}}

--- a/nodes/barn.py
+++ b/nodes/barn.py
@@ -7,11 +7,17 @@ from core.plugins import register_node_type
 
 class BarnNode(SimNode):
     """Simple barn used to shelter animals and equipment."""
-
-    def __init__(self, width: int | None = None, height: int | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        position: list[int] | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
+        self.position = position or [0, 0]
 
 
 register_node_type("BarnNode", BarnNode)

--- a/nodes/house.py
+++ b/nodes/house.py
@@ -7,11 +7,17 @@ from core.plugins import register_node_type
 
 class HouseNode(SimNode):
     """Represents a house where characters live and store resources."""
-
-    def __init__(self, width: int | None = None, height: int | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        position: list[int] | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
+        self.position = position or [0, 0]
 
 
 register_node_type("HouseNode", HouseNode)

--- a/nodes/pasture.py
+++ b/nodes/pasture.py
@@ -7,11 +7,17 @@ from core.plugins import register_node_type
 
 class PastureNode(SimNode):
     """Open grass area for animals."""
-
-    def __init__(self, width: int | None = None, height: int | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        position: list[int] | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
+        self.position = position or [0, 0]
 
 
 register_node_type("PastureNode", PastureNode)

--- a/nodes/silo.py
+++ b/nodes/silo.py
@@ -13,12 +13,14 @@ class SiloNode(SimNode):
         capacity: int | None = None,
         width: int | None = None,
         height: int | None = None,
+        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.capacity = capacity
         self.width = width
         self.height = height
+        self.position = position or [0, 0]
 
 
 register_node_type("SiloNode", SiloNode)

--- a/nodes/warehouse.py
+++ b/nodes/warehouse.py
@@ -7,11 +7,17 @@ from core.plugins import register_node_type
 
 class WarehouseNode(SimNode):
     """Represents a storage building."""
-
-    def __init__(self, width: int | None = None, height: int | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        position: list[int] | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
+        self.position = position or [0, 0]
 
 
 register_node_type("WarehouseNode", WarehouseNode)

--- a/nodes/well.py
+++ b/nodes/well.py
@@ -7,9 +7,9 @@ from core.plugins import register_node_type
 
 class WellNode(SimNode):
     """Simple well where characters can collect water."""
-
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, position: list[int] | None = None, **kwargs) -> None:
         super().__init__(**kwargs)
+        self.position = position or [0, 0]
 
 
 register_node_type("WellNode", WellNode)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -34,6 +34,7 @@ def test_map_editor_export_types(tmp_path: Path):
     from nodes.warehouse import WarehouseNode
     from nodes.well import WellNode
     from nodes.transform import TransformNode  # noqa: F401
+    import config
 
     types = [
         ("HouseNode", HouseNode),
@@ -51,5 +52,7 @@ def test_map_editor_export_types(tmp_path: Path):
     export(buildings, path)
     root = load_simulation_from_file(str(path))
     assert isinstance(root, WorldNode)
-    for node, (_, cls) in zip(root.children, types):
+    for i, (node, (_, cls)) in enumerate(zip(root.children, types)):
         assert isinstance(node, cls)
+        expected_x = (i * 10) // config.SCALE
+        assert node.position == [expected_x, 0]

--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -57,6 +57,7 @@ def export(buildings, path="custom_map.json") -> None:
         node = {
             "type": btype,
             "id": f"building{i}",
+            "config": {"position": [cell_x, cell_y]},
             "children": [
                 {
                     "type": "TransformNode",


### PR DESCRIPTION
## Summary
- allow BarnNode, HouseNode, SiloNode, PastureNode, WarehouseNode, and WellNode to accept an optional `position` list and store it
- export building positions in map editor configuration
- test map editor export to ensure node positions are set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689906c5bd308330b4144e83d907c378