### PR TITLE
Validate building bounds in map export

### DIFF
--- a/tests/test_map_editor_export.py
+++ b/tests/test_map_editor_export.py
@@ -1,6 +1,8 @@
 import pygame
 from pathlib import Path
 
+import pytest
+
 from core.loader import load_simulation_from_file
 from tools.map_editor import export
 from nodes.world import WorldNode
@@ -34,3 +36,22 @@ def test_export_and_reload_buildings(tmp_path: Path) -> None:
         assert node.position == expected_pos
         assert node.width is None
         assert node.height is None
+
+
+def test_export_rejects_negative_coordinates(tmp_path: Path) -> None:
+    buildings = [(pygame.Rect(-10, 0, 10, 20), "HouseNode")]
+    with pytest.raises(ValueError):
+        export(buildings, tmp_path / "map.json")
+
+
+def test_export_rejects_out_of_bounds(tmp_path: Path) -> None:
+    out_x = config.WORLD_WIDTH * config.SCALE + 1
+    buildings = [(pygame.Rect(out_x, 0, 10, 20), "BarnNode")]
+    with pytest.raises(ValueError):
+        export(buildings, tmp_path / "map.json")
+
+
+def test_export_rejects_non_positive_size(tmp_path: Path) -> None:
+    buildings = [(pygame.Rect(0, 0, 0, 10), "HouseNode")]
+    with pytest.raises(ValueError):
+        export(buildings, tmp_path / "map.json")

--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -54,6 +54,16 @@ def export(buildings, path="custom_map.json") -> None:
         }
     }
     for i, (rect, btype) in enumerate(buildings, 1):
+        if rect.width <= 0 or rect.height <= 0:
+            raise ValueError(f"Building {i} has non-positive size")
+        if (
+            rect.x < 0
+            or rect.y < 0
+            or rect.right > WORLD_WIDTH * SCALE
+            or rect.bottom > WORLD_HEIGHT * SCALE
+        ):
+            raise ValueError(f"Building {i} is out of bounds")
+
         cell_x = rect.x // SCALE
         cell_y = rect.y // SCALE
         node: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- ensure map exports fail if building sizes are non-positive or out of world bounds
- add tests for invalid coordinates and sizes

## Testing
- `pytest tests/test_map_editor_export.py`


------
https://chatgpt.com/codex/tasks/task_e_68990bd06a208330aace0ffb7fb8171d