### PR TITLE
Initialize pygame within map editor main

### DIFF
--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -23,8 +23,6 @@ if (
 ):
     os.environ["SDL_VIDEODRIVER"] = "dummy"
 
-pygame.init()
-
 SCALE = config.SCALE
 WORLD_WIDTH = config.WORLD_WIDTH
 WORLD_HEIGHT = config.WORLD_HEIGHT
@@ -84,6 +82,7 @@ def export(buildings, path="custom_map.json") -> None:
 
 
 def main(output_path: str = "custom_map.json") -> None:
+    pygame.init()
     screen = pygame.display.set_mode((WORLD_WIDTH * SCALE, WORLD_HEIGHT * SCALE))
     pygame.display.set_caption("Map Editor")
     clock = pygame.time.Clock()


### PR DESCRIPTION
## Summary
- remove top-level `pygame.init()`
- initialize pygame at start of `main()`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a2ae2e7d483309c5e83e85fe7ffe0