### PR TITLE
Export map on window close

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,4 +31,4 @@ The map editor (`tools/map_editor.py`) supports placing various building types. 
 - `5` – `WellNode`
 - `6` – `WarehouseNode`
 
-Press `E` to export the current map to JSON.
+Press `E` to export the current map to JSON, or simply close the window to save automatically.

--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -92,6 +92,7 @@ def main(output_path: str = "custom_map.json") -> None:
     while running:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
+                export(buildings, output_path)
                 running = False
             elif event.type == pygame.MOUSEBUTTONDOWN:
                 if event.button == 1:


### PR DESCRIPTION
## Summary
- Ensure map editor exports on window close
- Document auto-export when closing the map editor

## Testing
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8 (from versions: none))*
- `mypy tools/map_editor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a2c9260948330bec0d034d52f016f