### PR TITLE
feat: export building dimensions

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ FONT_SIZE = 14
 SCALE = 5
 WORLD_WIDTH = 240
 WORLD_HEIGHT = 144
+BUILDING_SIZE = 10  # in world units
 
 # Simulation timing
 FPS = 24

--- a/nodes/well.py
+++ b/nodes/well.py
@@ -7,8 +7,16 @@ from core.plugins import register_node_type
 
 class WellNode(SimNode):
     """Simple well where characters can collect water."""
-    def __init__(self, position: list[int] | None = None, **kwargs) -> None:
+    def __init__(
+        self,
+        width: int | None = None,
+        height: int | None = None,
+        position: list[int] | None = None,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
+        self.width = width
+        self.height = height
         self.position = position or [0, 0]
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -56,3 +56,6 @@ def test_map_editor_export_types(tmp_path: Path):
         assert isinstance(node, cls)
         expected_x = (i * 10) // config.SCALE
         assert node.position == [expected_x, 0]
+        expected_size = 10 // config.SCALE
+        assert node.width == expected_size
+        assert node.height == expected_size

--- a/tests/test_map_editor_export.py
+++ b/tests/test_map_editor_export.py
@@ -34,8 +34,10 @@ def test_export_and_reload_buildings(tmp_path: Path) -> None:
         assert isinstance(node, expected_cls)
         expected_pos = [rect.x // config.SCALE, rect.y // config.SCALE]
         assert node.position == expected_pos
-        assert node.width is None
-        assert node.height is None
+        expected_width = rect.width // config.SCALE
+        expected_height = rect.height // config.SCALE
+        assert node.width == expected_width
+        assert node.height == expected_height
 
 
 def test_export_rejects_negative_coordinates(tmp_path: Path) -> None:

--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -26,7 +26,7 @@ if (
 SCALE = config.SCALE
 WORLD_WIDTH = config.WORLD_WIDTH
 WORLD_HEIGHT = config.WORLD_HEIGHT
-BUILDING_SIZE = 10  # in world units
+BUILDING_SIZE = config.BUILDING_SIZE  # in world units
 
 COLOR_BG = (30, 30, 30)
 COLOR_BUILDING = (200, 180, 80)
@@ -68,7 +68,11 @@ def export(buildings, path="custom_map.json") -> None:
         node: dict[str, Any] = {
             "type": btype,
             "id": f"building{i}",
-            "config": {"position": [cell_x, cell_y]},
+            "config": {
+                "position": [cell_x, cell_y],
+                "width": rect.width // SCALE,
+                "height": rect.height // SCALE,
+            },
             "children": [
                 {
                     "type": "TransformNode",


### PR DESCRIPTION
## Summary
- centralize map editor building size in `config`
- export building width and height for each node
- allow `WellNode` to accept dimensions and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a31e1e7c8833084fcd25019d69ff7