### PR TITLE
refactor: centralize building positions in TransformNode

### DIFF
--- a/nodes/barn.py
+++ b/nodes/barn.py
@@ -11,13 +11,11 @@ class BarnNode(SimNode):
         self,
         width: int | None = None,
         height: int | None = None,
-        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
-        self.position = position or [0, 0]
 
 
 register_node_type("BarnNode", BarnNode)

--- a/nodes/house.py
+++ b/nodes/house.py
@@ -11,13 +11,11 @@ class HouseNode(SimNode):
         self,
         width: int | None = None,
         height: int | None = None,
-        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
-        self.position = position or [0, 0]
 
 
 register_node_type("HouseNode", HouseNode)

--- a/nodes/pasture.py
+++ b/nodes/pasture.py
@@ -11,13 +11,11 @@ class PastureNode(SimNode):
         self,
         width: int | None = None,
         height: int | None = None,
-        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
-        self.position = position or [0, 0]
 
 
 register_node_type("PastureNode", PastureNode)

--- a/nodes/silo.py
+++ b/nodes/silo.py
@@ -13,14 +13,12 @@ class SiloNode(SimNode):
         capacity: int | None = None,
         width: int | None = None,
         height: int | None = None,
-        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.capacity = capacity
         self.width = width
         self.height = height
-        self.position = position or [0, 0]
 
 
 register_node_type("SiloNode", SiloNode)

--- a/nodes/warehouse.py
+++ b/nodes/warehouse.py
@@ -11,13 +11,11 @@ class WarehouseNode(SimNode):
         self,
         width: int | None = None,
         height: int | None = None,
-        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
-        self.position = position or [0, 0]
 
 
 register_node_type("WarehouseNode", WarehouseNode)

--- a/nodes/well.py
+++ b/nodes/well.py
@@ -11,13 +11,11 @@ class WellNode(SimNode):
         self,
         width: int | None = None,
         height: int | None = None,
-        position: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.width = width
         self.height = height
-        self.position = position or [0, 0]
 
 
 register_node_type("WellNode", WellNode)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -54,8 +54,11 @@ def test_map_editor_export_types(tmp_path: Path):
     assert isinstance(root, WorldNode)
     for i, (node, (_, cls)) in enumerate(zip(root.children, types)):
         assert isinstance(node, cls)
+        transform = next(
+            child for child in node.children if isinstance(child, TransformNode)
+        )
         expected_x = (i * 10) // config.SCALE
-        assert node.position == [expected_x, 0]
+        assert transform.position == [expected_x, 0]
         expected_size = 10 // config.SCALE
         assert node.width == expected_size
         assert node.height == expected_size

--- a/tests/test_map_editor_export.py
+++ b/tests/test_map_editor_export.py
@@ -33,8 +33,11 @@ def test_export_and_reload_buildings(tmp_path: Path) -> None:
     for (rect, btype), node in zip(buildings, root.children):
         expected_cls = HouseNode if btype == "HouseNode" else BarnNode
         assert isinstance(node, expected_cls)
+        transform = next(
+            child for child in node.children if isinstance(child, TransformNode)
+        )
         expected_pos = [rect.x // config.SCALE, rect.y // config.SCALE]
-        assert node.position == expected_pos
+        assert transform.position == expected_pos
         expected_width = rect.width // config.SCALE
         expected_height = rect.height // config.SCALE
         assert node.width == expected_width

--- a/tools/map_editor.py
+++ b/tools/map_editor.py
@@ -108,7 +108,6 @@ def export(buildings, path="custom_map.json") -> None:
             "type": btype,
             "id": f"building{i}",
             "config": {
-                "position": [cell_x, cell_y],
                 "width": rect.width // SCALE,
                 "height": rect.height // SCALE,
             },


### PR DESCRIPTION
## Summary
- remove `position` attribute from building nodes
- export building locations only via `TransformNode`
- update tests to expect transform-based positions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a367afdac8330be9e8f34cb07ff91