### PR TITLE
Add configuration schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Project objectives, current progress and the complete roadmap live in [project_s
 
 An example configuration file `example_farm.json` demonstrates a minimal world setup loaded via the declarative loader.
 
+Configurations are validated against a schema to catch structural errors early and ensure community scenarios remain consistent.
+
 Configurations may include a `seed` in the `WorldNode` configuration to ensure
 deterministic simulations.
 

--- a/core/loader.py
+++ b/core/loader.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import inspect
 
 from .plugins import get_node_type
+from .schema import validate_simulation_config
 
 try:  # optional YAML support
     import yaml  # type: ignore
@@ -17,8 +18,7 @@ except Exception:  # pragma: no cover - yaml not installed
 def load_simulation_from_file(path: str) -> Any:
     """Load a simulation tree from a JSON or YAML file."""
     data = _load_data(Path(path))
-    if not isinstance(data, dict) or len(data) != 1:
-        raise ValueError("Configuration must contain a single root node")
+    validate_simulation_config(data)
     root_name, spec = next(iter(data.items()))
     return _build_node(spec, root_name)
 

--- a/core/schema.py
+++ b/core/schema.py
@@ -1,0 +1,86 @@
+"""Schema validation utilities for simulation configuration files."""
+from __future__ import annotations
+
+from typing import Any
+
+try:  # optional dependency
+    from jsonschema import Draft7Validator, ValidationError  # type: ignore
+except Exception:  # pragma: no cover - jsonschema not installed
+    Draft7Validator = None  # type: ignore
+
+    class ValidationError(Exception):
+        """Raised when configuration validation fails."""
+
+
+CONFIG_SCHEMA = {
+    "type": "object",
+    "minProperties": 1,
+    "maxProperties": 1,
+    "patternProperties": {"^.+$": {"$ref": "#/definitions/node"}},
+    "additionalProperties": False,
+    "definitions": {
+        "node": {
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+                "type": {"type": "string"},
+                "id": {"type": "string"},
+                "config": {"type": "object"},
+                "children": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/node"},
+                },
+            },
+            "additionalProperties": False,
+        }
+    },
+}
+
+if Draft7Validator is not None:  # pragma: no cover - exercised in environments with jsonschema
+    _validator = Draft7Validator(CONFIG_SCHEMA)
+
+    def validate_simulation_config(data: Any) -> None:
+        """Validate configuration using :mod:`jsonschema` if available."""
+
+        _validator.validate(data)
+
+else:
+
+    def validate_simulation_config(data: Any) -> None:
+        """Validate configuration using a simple Python implementation."""
+
+        _validate_root(data)
+
+
+def _validate_root(data: Any) -> None:
+    if not isinstance(data, dict) or len(data) != 1:
+        raise ValidationError("Configuration must contain a single root node")
+    for spec in data.values():
+        _validate_node(spec)
+
+
+def _validate_node(spec: Any) -> None:
+    if not isinstance(spec, dict):
+        raise ValidationError("Node specification must be a mapping")
+    required = {"type"}
+    allowed = {"type", "id", "config", "children"}
+    missing = required - spec.keys()
+    if missing:
+        raise ValidationError(f"Missing keys in node specification: {missing}")
+    if not isinstance(spec["type"], str):
+        raise ValidationError("'type' must be a string")
+    extra = set(spec) - allowed
+    if extra:
+        raise ValidationError(f"Unknown keys in node specification: {extra}")
+    if "config" in spec and not isinstance(spec["config"], dict):
+        raise ValidationError("'config' must be a mapping")
+    if "children" in spec:
+        children = spec["children"]
+        if not isinstance(children, list):
+            raise ValidationError("'children' must be a list")
+        for child in children:
+            _validate_node(child)
+
+
+__all__ = ["validate_simulation_config", "ValidationError", "CONFIG_SCHEMA"]
+

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from core.loader import load_simulation_from_file
+from core.schema import ValidationError
+from nodes.world import WorldNode  # ensure plugin registration
+
+
+def test_missing_type_raises_validation_error(tmp_path: Path) -> None:
+    config = {"world": {"config": {}}}
+    path = tmp_path / "world.json"
+    path.write_text(json.dumps(config))
+    with pytest.raises(ValidationError):
+        load_simulation_from_file(str(path))
+
+
+def test_multiple_roots_raises_validation_error(tmp_path: Path) -> None:
+    config = {
+        "world": {"type": "WorldNode"},
+        "other": {"type": "WorldNode"},
+    }
+    path = tmp_path / "world.json"
+    path.write_text(json.dumps(config))
+    with pytest.raises(ValidationError):
+        load_simulation_from_file(str(path))
+


### PR DESCRIPTION
## Summary
- validate configuration files against a structured schema
- enforce validation in the loader to catch structural errors
- document the validation step and test invalid configurations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a4b84c3088330841af093410a4027