### PR TITLE
feat: enhance map editor with characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ configuration files for new simulations. Launch it with:
 python tools/map_editor.py [output.json]
 ```
 
-Use the mouse to place buildings and the number keys `1`–`6` to switch between
-building types. Right‑click deletes the topmost building under the cursor and
-pressing `Z` undoes the most recent placement. Export the map at any time with
-`E` or simply close the window to write the chosen JSON file. The editor writes
-`WorldNode` JSON with each building entry containing its `type` and grid
-`position`. A minimal example looks like:
+Use the mouse to place objects on the map. Number keys `1`–`6` switch between
+building types while `M` and `F` select male or female characters. Right‑click
+deletes the topmost item under the cursor and pressing `Z` undoes the most
+recent placement. Export the map at any time with `E` or simply close the
+window to write the chosen JSON file. The editor writes `WorldNode` JSON with
+each building or character entry containing its `type` and grid `position`. A
+minimal example with a single barn looks like:
 
 ```json
 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,4 +31,9 @@ The map editor (`tools/map_editor.py`) supports placing various building types. 
 - `5` – `WellNode`
 - `6` – `WarehouseNode`
 
+Characters can also be placed on the map:
+
+- `M` – male `CharacterNode`
+- `F` – female `CharacterNode`
+
 Press `E` to export the current map to JSON, or simply close the window to save automatically.

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -136,7 +136,7 @@ class PygameViewerSystem(SystemNode):
 
     def _info_lines(self, node: SimNode) -> List[str]:
         """Return a list of human-readable attributes for ``node``."""
-        lines: List[str] = [node.name]
+        lines: List[str] = [f"{node.name} ({node.__class__.__name__})"]
         for attr, value in vars(node).items():
             if attr.startswith("_") or attr in {"parent", "children"}:
                 continue

--- a/tests/test_map_editor_export.py
+++ b/tests/test_map_editor_export.py
@@ -10,6 +10,7 @@ from nodes.world import WorldNode
 from nodes.transform import TransformNode  # noqa: F401
 from nodes.house import HouseNode
 from nodes.barn import BarnNode
+from nodes.character import CharacterNode
 import config
 
 
@@ -42,6 +43,24 @@ def test_export_and_reload_buildings(tmp_path: Path) -> None:
         expected_height = rect.height // config.SCALE
         assert node.width == expected_width
         assert node.height == expected_height
+
+
+def test_export_and_reload_characters(tmp_path: Path) -> None:
+    buildings: list[tuple[pygame.Rect, str]] = []
+    characters = [((0, 0), "male"), ((10, 10), "female")]
+    path = tmp_path / "chars.json"
+    export(buildings, path, characters)
+    root = load_simulation_from_file(str(path))
+    assert isinstance(root, WorldNode)
+    chars = [c for c in root.children if isinstance(c, CharacterNode)]
+    assert len(chars) == 2
+    for (pos, gender), node in zip(characters, chars):
+        assert node.gender == gender
+        transform = next(
+            child for child in node.children if isinstance(child, TransformNode)
+        )
+        expected = [pos[0] // config.SCALE, pos[1] // config.SCALE]
+        assert transform.position == expected
 
 
 def test_export_rejects_negative_coordinates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- display node type in viewer info panel
- expand map editor with character placement and on-screen menu
- document new map editor controls

## Testing
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: Source file found twice under different module names: "map_editor" and "tools.map_editor")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba81b5b008330b929619fb1e0728e