### PR TITLE
feat: enhance map editor and scenario tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@ python run_farm.py
 ## Map editor
 
 An interactive map editor is provided in `tools/map_editor.py` to create
-configuration files for new simulations. Launch it with:
+layout files for new simulations. Launch it with:
 
 ```
-python tools/map_editor.py [output.json]
+python tools/map_editor.py [output.json] [keymap.json] [existing_map.json]
 ```
 
 Use the mouse to place objects on the map. Number keys `1`–`6` switch between
-building types while `M` and `F` select male or female characters. Right‑click
-deletes the topmost item under the cursor and pressing `Z` undoes the most
-recent placement. Export the map at any time with `E` or simply close the
-window to write the chosen JSON file. The editor writes `WorldNode` JSON with
-each building or character entry containing its `type` and grid `position`. A
-minimal example with a single barn looks like:
+building types while `M` and `F` select male or female characters. Press `S` to
+enter selection mode and use the arrow keys to resize the highlighted building.
+Right‑click deletes the topmost item under the cursor and pressing `Z` undoes
+the most recent placement. Export the map at any time with `E` or simply close
+the window to write the chosen JSON file. The editor writes `WorldNode` JSON
+with each building or character entry containing its `type` and grid
+`position`. A minimal example with a single barn looks like:
 
 ```json
 {
@@ -62,8 +63,16 @@ minimal example with a single barn looks like:
 }
 ```
 
-The editor's pixel scale and world dimensions are controlled by `SCALE`,
-`WORLD_WIDTH` and `WORLD_HEIGHT` in `config.py`.
+The editor focuses purely on spatial layout. To turn an exported map into a
+complete farm scenario, run:
+
+```
+python tools/build_farm_scenario.py custom_map.json scenario.json
+```
+
+`build_farm_scenario.py` adds inventories and the core systems (time, economy,
+viewer…) to the map file. The editor's pixel scale and world dimensions are
+controlled by `SCALE`, `WORLD_WIDTH` and `WORLD_HEIGHT` in `config.py`.
 
 ## Development
 

--- a/docs/guides/map_editor.md
+++ b/docs/guides/map_editor.md
@@ -1,0 +1,34 @@
+# Map editor
+
+The map editor in `tools/map_editor.py` is a lightweight layout tool. It lets you
+place buildings and characters on a grid and export the result as JSON. The
+exported file only describes spatial information; behavioural logic and systems
+are added separately.
+
+## Usage
+
+```
+python tools/map_editor.py [output.json] [keymap.json] [existing_map.json]
+```
+
+* **Left click** – place current item or select when in *select* mode.
+* **Right click** – delete item under cursor.
+* **1-6** – choose building type.
+* **M/F** – male/female character.
+* **S** – enter select/resize mode.
+* **Arrow keys** – resize selected building.
+* **Z** – undo last placement.
+* **E** – export map.
+
+Passing a previous map as `existing_map.json` loads its contents for further
+editing.
+
+To transform the exported layout into a runnable farm scenario use
+`tools/build_farm_scenario.py`:
+
+```
+python tools/build_farm_scenario.py custom_map.json scenario.json
+```
+
+This adds basic inventories and core systems (time, economy, viewer…) to the
+map file.

--- a/tests/test_build_farm_scenario.py
+++ b/tests/test_build_farm_scenario.py
@@ -1,0 +1,32 @@
+from tools.build_farm_scenario import build
+import json
+import tempfile
+import os
+
+def test_build_adds_systems_and_inventories(tmp_path):
+    data = {
+        "world": {
+            "type": "WorldNode",
+            "config": {"width": 10, "height": 10},
+            "children": [
+                {
+                    "type": "HouseNode",
+                    "id": "building1",
+                    "config": {"width": 1, "height": 1},
+                    "children": [
+                        {"type": "TransformNode", "config": {"position": [0, 0]}}
+                    ],
+                }
+            ],
+        }
+    }
+    src = tmp_path / "map.json"
+    out = tmp_path / "scenario.json"
+    src.write_text(json.dumps(data))
+    build(str(src), str(out))
+    result = json.loads(out.read_text())
+    children = result["world"]["children"]
+    house = next(c for c in children if c["type"] == "HouseNode")
+    assert any(c["type"] == "InventoryNode" for c in house["children"])
+    system_types = {c["type"] for c in children if c["type"].endswith("System")}
+    assert {"TimeSystem", "EconomySystem", "LoggingSystem", "DistanceSystem", "PygameViewerSystem"} <= system_types

--- a/tools/build_farm_scenario.py
+++ b/tools/build_farm_scenario.py
@@ -1,0 +1,41 @@
+import json
+import sys
+
+INVENTORY_BUILDINGS = {
+    "HouseNode",
+    "BarnNode",
+    "SiloNode",
+    "PastureNode",
+    "FarmNode",
+    "WellNode",
+    "WarehouseNode",
+}
+
+SYSTEM_NODES = [
+    {"type": "TimeSystem"},
+    {"type": "EconomySystem"},
+    {"type": "LoggingSystem"},
+    {"type": "DistanceSystem"},
+    {"type": "PygameViewerSystem"},
+]
+
+def build(map_file: str, output: str) -> None:
+    with open(map_file, "r", encoding="utf8") as fh:
+        data = json.load(fh)
+    world = data["world"]
+    children = world.setdefault("children", [])
+    for node in children:
+        if node.get("type") in INVENTORY_BUILDINGS:
+            inv_id = f"{node.get('id', 'node')}_inventory"
+            node.setdefault("children", []).append(
+                {"type": "InventoryNode", "id": inv_id, "config": {"items": {}}}
+            )
+    children.extend(SYSTEM_NODES)
+    with open(output, "w", encoding="utf8") as fh:
+        json.dump(data, fh, indent=2)
+    print(f"Wrote farm scenario to {output}")
+
+if __name__ == "__main__":
+    in_file = sys.argv[1] if len(sys.argv) > 1 else "custom_map.json"
+    out_file = sys.argv[2] if len(sys.argv) > 2 else "farm_scenario.json"
+    build(in_file, out_file)


### PR DESCRIPTION
## Summary
- allow map editor to load existing maps and resize buildings via selection mode
- add farm scenario builder script and documentation
- document map editor usage and provide basic scenario conversion test

## Testing
- `python -m py_compile tools/map_editor.py tools/build_farm_scenario.py`
- `mypy tools/map_editor.py tools/build_farm_scenario.py`
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb0b374f8833081f02c8f416d4d4c