### PR TITLE
feat: generalize scenario builder and document roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@ python run_farm.py
 ## Map editor
 
 An interactive map editor is provided in `tools/map_editor.py` to create
-configuration files for new simulations. Launch it with:
+layout files for new simulations. Launch it with:
 
 ```
-python tools/map_editor.py [output.json]
+python tools/map_editor.py [output.json] [keymap.json] [existing_map.json]
 ```
 
 Use the mouse to place objects on the map. Number keys `1`–`6` switch between
-building types while `M` and `F` select male or female characters. Right‑click
-deletes the topmost item under the cursor and pressing `Z` undoes the most
-recent placement. Export the map at any time with `E` or simply close the
-window to write the chosen JSON file. The editor writes `WorldNode` JSON with
-each building or character entry containing its `type` and grid `position`. A
-minimal example with a single barn looks like:
+building types while `M` and `F` select male or female characters. Press `S` to
+enter selection mode and use the arrow keys to resize the highlighted building.
+Right‑click deletes the topmost item under the cursor and pressing `Z` undoes
+the most recent placement. Export the map at any time with `E` or simply close
+the window to write the chosen JSON file. The editor writes `WorldNode` JSON
+with each building or character entry containing its `type` and grid
+`position`. A minimal example with a single barn looks like:
 
 ```json
 {
@@ -62,8 +63,17 @@ minimal example with a single barn looks like:
 }
 ```
 
-The editor's pixel scale and world dimensions are controlled by `SCALE`,
-`WORLD_WIDTH` and `WORLD_HEIGHT` in `config.py`.
+The editor focuses purely on spatial layout. To turn an exported map into a
+complete scenario, run:
+
+```
+python tools/build_scenario.py custom_map.json scenario.json [profile]
+```
+
+`build_scenario.py` adds inventories and the core systems (time, economy,
+viewer…) to the map file based on the selected `profile` (default: `farm`).
+The editor's pixel scale and world dimensions are
+controlled by `SCALE`, `WORLD_WIDTH` and `WORLD_HEIGHT` in `config.py`.
 
 ## Development
 

--- a/docs/checklists/todo.md
+++ b/docs/checklists/todo.md
@@ -23,6 +23,21 @@ This checklist gathers outstanding tasks from the project specification and main
 - [ ] **Low** Configuration auto-completion and linting support for editors.
 - [ ] **Low** Behaviour scripting DSL with a safe sandbox.
 
+### Map Editor & Scenario Builder
+- [ ] Clarify documentation: editor handles spatial layout while scenarios add behaviour and systems.
+- [ ] Generic scenario builder supporting multiple profiles (farm, quest, battle…).
+- [ ] Load and edit existing maps or scenarios from JSON.
+- [ ] In-editor property panel to configure node attributes.
+- [ ] Visual linking tool to define dependencies between nodes.
+- [ ] Scenario profiles and presets for different genres.
+- [ ] Export extended to include properties and links with plugin-based validation.
+- [ ] Optional simulation preview launched directly from the editor.
+- [ ] Refactor map editor into UI, node management and serialisation modules.
+- [ ] Dynamic form generation for node-specific properties.
+- [ ] Graphical module to manage and display links between nodes.
+- [ ] Round-trip tests and CLI to combine map layouts with scenario profiles.
+- [ ] Documentation and examples for non-farm scenarios.
+
 ## Visualization and Rendering
 - [ ] **Medium** Extend the Pygame viewer with camera controls, zoom and overlays.
 - [ ] **Low** Headless rendering mode that streams frames or state for remote dashboards.

--- a/docs/guides/map_editor.md
+++ b/docs/guides/map_editor.md
@@ -1,0 +1,34 @@
+# Map editor
+
+The map editor in `tools/map_editor.py` is a lightweight layout tool. It lets you
+place buildings and characters on a grid and export the result as JSON. The
+exported file only describes spatial information; behavioural logic and systems
+are added separately.
+
+## Usage
+
+```
+python tools/map_editor.py [output.json] [keymap.json] [existing_map.json]
+```
+
+* **Left click** – place current item or select when in *select* mode.
+* **Right click** – delete item under cursor.
+* **1-6** – choose building type.
+* **M/F** – male/female character.
+* **S** – enter select/resize mode.
+* **Arrow keys** – resize selected building.
+* **Z** – undo last placement.
+* **E** – export map.
+
+Passing a previous map as `existing_map.json` loads its contents for further
+editing.
+
+To transform the exported layout into a runnable scenario use
+`tools/build_scenario.py`:
+
+```
+python tools/build_scenario.py custom_map.json scenario.json [profile]
+```
+
+This adds basic inventories and core systems (time, economy, viewer…) based on
+the chosen `profile` (default: `farm`).

--- a/tests/test_build_scenario.py
+++ b/tests/test_build_scenario.py
@@ -1,0 +1,32 @@
+from tools.build_scenario import build
+import json
+import tempfile
+import os
+
+def test_build_adds_systems_and_inventories(tmp_path):
+    data = {
+        "world": {
+            "type": "WorldNode",
+            "config": {"width": 10, "height": 10},
+            "children": [
+                {
+                    "type": "HouseNode",
+                    "id": "building1",
+                    "config": {"width": 1, "height": 1},
+                    "children": [
+                        {"type": "TransformNode", "config": {"position": [0, 0]}}
+                    ],
+                }
+            ],
+        }
+    }
+    src = tmp_path / "map.json"
+    out = tmp_path / "scenario.json"
+    src.write_text(json.dumps(data))
+    build(str(src), str(out), scenario="farm")
+    result = json.loads(out.read_text())
+    children = result["world"]["children"]
+    house = next(c for c in children if c["type"] == "HouseNode")
+    assert any(c["type"] == "InventoryNode" for c in house["children"])
+    system_types = {c["type"] for c in children if c["type"].endswith("System")}
+    assert {"TimeSystem", "EconomySystem", "LoggingSystem", "DistanceSystem", "PygameViewerSystem"} <= system_types

--- a/tools/build_scenario.py
+++ b/tools/build_scenario.py
@@ -1,0 +1,85 @@
+"""Utilities to turn a map layout into a runnable scenario.
+
+Currently only a *farm* profile is provided but additional profiles can be
+added to :data:`SCENARIOS` to support other genres such as quests or battles.
+"""
+
+import json
+import sys
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class ScenarioProfile:
+    """Defines extra nodes injected when building a scenario."""
+
+    inventory_buildings: Iterable[str]
+    system_nodes: List[dict]
+
+
+SCENARIOS: Dict[str, ScenarioProfile] = {
+    "farm": ScenarioProfile(
+        inventory_buildings={
+            "HouseNode",
+            "BarnNode",
+            "SiloNode",
+            "PastureNode",
+            "FarmNode",
+            "WellNode",
+            "WarehouseNode",
+        },
+        system_nodes=[
+            {"type": "TimeSystem"},
+            {"type": "EconomySystem"},
+            {"type": "LoggingSystem"},
+            {"type": "DistanceSystem"},
+            {"type": "PygameViewerSystem"},
+        ],
+    )
+}
+
+
+def build(map_file: str, output: str, scenario: str = "farm") -> None:
+    """Combine a layout exported from the map editor with scenario extras.
+
+    Parameters
+    ----------
+    map_file:
+        Path to the JSON file produced by ``map_editor.py``.
+    output:
+        Location where the enriched scenario should be written.
+    scenario:
+        Key of the scenario profile to apply.
+    """
+
+    profile = SCENARIOS.get(scenario)
+    if profile is None:
+        raise ValueError(f"Unknown scenario profile: {scenario}")
+
+    with open(map_file, "r", encoding="utf8") as fh:
+        data = json.load(fh)
+
+    world = data["world"]
+    children = world.setdefault("children", [])
+
+    for node in children:
+        if node.get("type") in profile.inventory_buildings:
+            inv_id = f"{node.get('id', 'node')}_inventory"
+            node.setdefault("children", []).append(
+                {"type": "InventoryNode", "id": inv_id, "config": {"items": {}}}
+            )
+
+    children.extend(profile.system_nodes)
+
+    with open(output, "w", encoding="utf8") as fh:
+        json.dump(data, fh, indent=2)
+
+    print(f"Wrote {scenario} scenario to {output}")
+
+
+if __name__ == "__main__":
+    in_file = sys.argv[1] if len(sys.argv) > 1 else "custom_map.json"
+    out_file = sys.argv[2] if len(sys.argv) > 2 else "scenario.json"
+    scenario = sys.argv[3] if len(sys.argv) > 3 else "farm"
+    build(in_file, out_file, scenario)


### PR DESCRIPTION
## Summary
- rename farm-specific builder to generic `build_scenario.py` with support for scenario profiles
- update map editor docs and README to describe scenario profile workflow
- capture future map editor tasks in project checklist

## Testing
- `python -m py_compile tools/map_editor.py tools/build_scenario.py`
- `mypy tools/map_editor.py tools/build_scenario.py`
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb0b374f8833081f02c8f416d4d4c