### PR TITLE
Verify war simulation engine setup

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -3,7 +3,7 @@
 This roadmap breaks down the tasks required to build the simplified war simulation scenario on top of the Nodari engine. Each item provides enough context to implement the feature without referring back to the specs.
 
 ## Foundations
-- [ ] **Confirm engine setup** – Reuse the existing `SimNode`, event bus, systems and declarative loader from the core project.
+- [x] **Confirm engine setup** – Reuse the existing `SimNode`, event bus, systems and declarative loader from the core project.
 - [ ] **Create base configuration** – In `example/war_simulation_config.json`, describe two nations, their generals, starting armies (100 units each) and initial terrain layout.
 
 ## Domain Nodes

--- a/tests/test_war_engine_setup.py
+++ b/tests/test_war_engine_setup.py
@@ -1,0 +1,28 @@
+import json
+
+from core.loader import load_simulation_from_file
+from nodes.world import WorldNode  # ensure plugin registration
+from systems.time import TimeSystem
+
+
+def test_war_engine_setup(tmp_path):
+    config = {
+        "war_world": {
+            "type": "WorldNode",
+            "children": [
+                {"type": "TimeSystem", "id": "time"}
+            ],
+        }
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+
+    world = load_simulation_from_file(str(config_path))
+    assert isinstance(world, WorldNode)
+
+    time_system = next(child for child in world.children if isinstance(child, TimeSystem))
+    ticks: list[int] = []
+    time_system.on_event("tick", lambda _o, _e, payload: ticks.append(payload["tick"]))
+
+    world.update(1.0)
+    assert ticks == [1]


### PR DESCRIPTION
## Summary
- add test ensuring war simulation uses existing engine components (SimNode, TimeSystem, loader)
- mark engine setup item complete in war simulation roadmap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0edb12b2083308ba59f4ab75d843f