### PR TITLE
Add base war simulation configuration

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -4,7 +4,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 
 ## Foundations
 - [x] **Confirm engine setup** – Reuse the existing `SimNode`, event bus, systems and declarative loader from the core project.
-- [ ] **Create base configuration** – In `example/war_simulation_config.json`, describe two nations, their generals, starting armies (100 units each) and initial terrain layout.
+- [x] **Create base configuration** – In `example/war_simulation_config.json`, describe two nations, their generals, starting armies (100 units each) and initial terrain layout.
 
 ## Domain Nodes
 - [ ] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -1,0 +1,42 @@
+{
+  "war_world": {
+    "type": "WorldNode",
+    "config": {"width": 100, "height": 50, "seed": 1},
+    "children": [
+      {"type": "TimeSystem", "id": "time"},
+      {"type": "TerrainNode", "id": "terrain", "config": {
+        "tiles": [
+          ["plain", "plain", "plain", "plain", "plain"],
+          ["plain", "plain", "plain", "plain", "plain"],
+          ["plain", "plain", "plain", "plain", "plain"]
+        ]
+      }},
+      {"type": "NationNode", "id": "north", "config": {"capital_position": [5, 25], "morale": 100},
+        "children": [
+          {"type": "GeneralNode", "id": "north_general", "config": {"style": "balanced"},
+            "children": [
+              {"type": "ArmyNode", "id": "north_army", "config": {"goal": "advance"},
+                "children": [
+                  {"type": "UnitNode", "id": "north_unit_1", "config": {"size": 100, "state": "idle"}}
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {"type": "NationNode", "id": "south", "config": {"capital_position": [95, 25], "morale": 100},
+        "children": [
+          {"type": "GeneralNode", "id": "south_general", "config": {"style": "balanced"},
+            "children": [
+              {"type": "ArmyNode", "id": "south_army", "config": {"goal": "advance"},
+                "children": [
+                  {"type": "UnitNode", "id": "south_unit_1", "config": {"size": 100, "state": "idle"}}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- create initial war simulation configuration with two nations, generals, armies, and terrain
- mark roadmap checklist item for base configuration as complete

## Testing
- `pytest`
- `flake8` *(fails: command not found, dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef3e97a48330a62b36242eca76f0