### PR TITLE
Implement NationNode for war simulation

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -7,7 +7,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **Create base configuration** – In `example/war_simulation_config.json`, describe two nations, their generals, starting armies (100 units each) and initial terrain layout.
 
 ## Domain Nodes
-- [ ] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.
+ - [x] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.
 - [ ] **GeneralNode** – Stores tactical style (aggressive/defensive/balanced) and owns one or more armies. Listens to partial battlefield events due to fog of war.
 - [ ] **ArmyNode** – Groups `UnitNode`s, tracks goal (advance, defend, retreat) and current size. Interfaces with Movement and Combat systems.
 - [ ] **UnitNode** – Represents ~100 soldiers with state (moving, fighting, fleeing) and attributes such as speed and morale. Emits `unit_engaged` and `unit_routed`.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -80,6 +80,14 @@
 | items | Optional[Dict[str, int]] | None |  |
 | kwargs | _empty |  |  |
 
+### NationNode
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| morale | int |  |  Initial morale value. |
+| capital_position | List[int] |  |  ``[x, y]`` coordinates of the nation's capital. |
+| kwargs | _empty |  |  |
+
 ### NeedNode
 
 | Parameter | Type | Default | Description |

--- a/nodes/nation.py
+++ b/nodes/nation.py
@@ -1,0 +1,69 @@
+"""Nation node representing a faction in the war simulation."""
+from __future__ import annotations
+
+from typing import List
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class NationNode(SimNode):
+    """Represent a nation with morale and capital position.
+
+    Parameters
+    ----------
+    morale:
+        Initial morale value.
+    capital_position:
+        ``[x, y]`` coordinates of the nation's capital.
+    """
+
+    def __init__(self, morale: int, capital_position: List[int], **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.morale = morale
+        self.capital_position = capital_position
+
+    # ------------------------------------------------------------------
+    def change_morale(self, delta: int) -> None:
+        """Adjust morale by *delta* and emit ``moral_changed``."""
+
+        previous = self.morale
+        self.morale += delta
+        self.emit(
+            "moral_changed",
+            {"previous": previous, "morale": self.morale, "delta": delta},
+            direction="down",
+        )
+
+    # ------------------------------------------------------------------
+    def capture_capital(self) -> None:
+        """Emit ``capital_captured`` for this nation's capital."""
+
+        self.emit(
+            "capital_captured",
+            {"position": self.capital_position},
+            direction="down",
+        )
+
+    # ------------------------------------------------------------------
+    def get_generals(self) -> List[SimNode]:
+        """Return direct child nodes considered generals."""
+
+        return [c for c in self.children if c.__class__.__name__ == "GeneralNode"]
+
+    # ------------------------------------------------------------------
+    def get_armies(self) -> List[SimNode]:
+        """Return all descendant nodes considered armies."""
+
+        armies: List[SimNode] = []
+        stack = list(self.children)
+        while stack:
+            node = stack.pop()
+            if node.__class__.__name__ == "ArmyNode":
+                armies.append(node)
+            stack.extend(node.children)
+        return armies
+
+
+register_node_type("NationNode", NationNode)
+

--- a/tests/test_nation_node.py
+++ b/tests/test_nation_node.py
@@ -1,0 +1,44 @@
+from core.simnode import SimNode
+from nodes.nation import NationNode
+
+
+def test_morale_change_emits_event():
+    nation = NationNode(morale=100, capital_position=[0, 0])
+    events: list[dict] = []
+    nation.on_event("moral_changed", lambda _o, _e, payload: events.append(payload))
+
+    nation.change_morale(-10)
+
+    assert nation.morale == 90
+    assert events[0]["previous"] == 100
+    assert events[0]["morale"] == 90
+    assert events[0]["delta"] == -10
+
+
+def test_capital_capture_emits_event():
+    nation = NationNode(morale=50, capital_position=[5, 5])
+    events: list[dict] = []
+    nation.on_event("capital_captured", lambda _o, _e, payload: events.append(payload))
+
+    nation.capture_capital()
+
+    assert events[0]["position"] == [5, 5]
+
+
+def test_references_generals_and_armies():
+    class GeneralNode(SimNode):
+        pass
+
+    class ArmyNode(SimNode):
+        pass
+
+    army = ArmyNode(name="army")
+    general = GeneralNode(name="general")
+    general.add_child(army)
+
+    nation = NationNode(morale=100, capital_position=[0, 0])
+    nation.add_child(general)
+
+    assert nation.get_generals() == [general]
+    assert nation.get_armies() == [army]
+


### PR DESCRIPTION
## Summary
- add NationNode with morale tracking, capital capture events, and helpers to gather generals and armies
- document NationNode parameters and mark roadmap item complete

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0f08ee8008330bafbf07426ddc7f9