### PR TITLE
Add GeneralNode for war simulation

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -7,8 +7,8 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **Create base configuration** – In `example/war_simulation_config.json`, describe two nations, their generals, starting armies (100 units each) and initial terrain layout.
 
 ## Domain Nodes
- - [x] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.
-- [ ] **GeneralNode** – Stores tactical style (aggressive/defensive/balanced) and owns one or more armies. Listens to partial battlefield events due to fog of war.
+- [x] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.
+- [x] **GeneralNode** – Stores tactical style (aggressive/defensive/balanced) and owns one or more armies. Listens to partial battlefield events due to fog of war.
 - [ ] **ArmyNode** – Groups `UnitNode`s, tracks goal (advance, defend, retreat) and current size. Interfaces with Movement and Combat systems.
 - [ ] **UnitNode** – Represents ~100 soldiers with state (moving, fighting, fleeing) and attributes such as speed and morale. Emits `unit_engaged` and `unit_routed`.
 - [ ] **TerrainNode** – Defines map tiles: plain, forest, hill. Influences movement speed and combat bonuses.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -65,6 +65,13 @@
 | height | int | None | None |  |
 | kwargs | _empty |  |  |
 
+### GeneralNode
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| style | str |  | Tactical approach of the general (``"aggressive"``, ``"defensive"`` or ``"balanced"``). |
+| kwargs | _empty |  |  |
+
 ### HouseNode
 
 | Parameter | Type | Default | Description |

--- a/nodes/general.py
+++ b/nodes/general.py
@@ -1,0 +1,39 @@
+"""General node representing a military leader in the war simulation."""
+from __future__ import annotations
+
+from typing import List, Dict
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class GeneralNode(SimNode):
+    """Represent a general with a tactical style and battlefield reports.
+
+    Parameters
+    ----------
+    style:
+        Tactical approach of the general: ``"aggressive"``, ``"defensive"``
+        or ``"balanced"``.
+    """
+
+    def __init__(self, style: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.style = style
+        self.reports: List[Dict] = []
+        self.on_event("battlefield_event", self._record_report)
+
+    # ------------------------------------------------------------------
+    def _record_report(self, _origin: SimNode, _event: str, payload: Dict) -> None:
+        """Store a partial battlefield report in ``reports``."""
+
+        self.reports.append(payload)
+
+    # ------------------------------------------------------------------
+    def get_armies(self) -> List[SimNode]:
+        """Return direct child nodes considered armies."""
+
+        return [c for c in self.children if c.__class__.__name__ == "ArmyNode"]
+
+
+register_node_type("GeneralNode", GeneralNode)

--- a/tests/test_general_node.py
+++ b/tests/test_general_node.py
@@ -1,0 +1,18 @@
+from core.simnode import SimNode
+from nodes.general import GeneralNode
+
+
+def test_general_records_style_and_reports():
+    general = GeneralNode(style="aggressive")
+
+    class ArmyNode(SimNode):
+        pass
+
+    army = ArmyNode(name="army")
+    general.add_child(army)
+
+    army.emit("battlefield_event", {"sector": 1})
+
+    assert general.style == "aggressive"
+    assert general.reports[0]["sector"] == 1
+    assert general.get_armies() == [army]


### PR DESCRIPTION
## Summary
- implement GeneralNode with tactical style, battlefield reports and army lookup
- document GeneralNode parameters and mark roadmap step complete
- add tests for GeneralNode behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f271227c8330951a30c73f859274