### PR TITLE
Add ArmyNode for war simulation

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -9,7 +9,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 ## Domain Nodes
 - [x] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.
 - [x] **GeneralNode** – Stores tactical style (aggressive/defensive/balanced) and owns one or more armies. Listens to partial battlefield events due to fog of war.
-- [ ] **ArmyNode** – Groups `UnitNode`s, tracks goal (advance, defend, retreat) and current size. Interfaces with Movement and Combat systems.
+- [x] **ArmyNode** – Groups `UnitNode`s, tracks goal (advance, defend, retreat) and current size. Interfaces with Movement and Combat systems.
 - [ ] **UnitNode** – Represents ~100 soldiers with state (moving, fighting, fleeing) and attributes such as speed and morale. Emits `unit_engaged` and `unit_routed`.
 - [ ] **TerrainNode** – Defines map tiles: plain, forest, hill. Influences movement speed and combat bonuses.
 

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -42,6 +42,14 @@
 | producer | ResourceProducerNode | None | None |  |
 | kwargs | _empty |  |  |
 
+### ArmyNode
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| goal | str |  |  Current objective of the army: ``"advance"``, ``"defend"`` or ``"retreat"``. |
+| size | int | 0 |  Number of unit groups in the army. |
+| kwargs | _empty |  |  |
+
 ### BarnNode
 
 | Parameter | Type | Default | Description |
@@ -69,7 +77,7 @@
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| style | str |  | Tactical approach of the general (``"aggressive"``, ``"defensive"`` or ``"balanced"``). |
+| style | str |  |  Tactical approach of the general: ``"aggressive"``, ``"defensive"`` or ``"balanced"``. |
 | kwargs | _empty |  |  |
 
 ### HouseNode

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -15,7 +15,7 @@
         "children": [
           {"type": "GeneralNode", "id": "north_general", "config": {"style": "balanced"},
             "children": [
-              {"type": "ArmyNode", "id": "north_army", "config": {"goal": "advance"},
+              {"type": "ArmyNode", "id": "north_army", "config": {"goal": "advance", "size": 1},
                 "children": [
                   {"type": "UnitNode", "id": "north_unit_1", "config": {"size": 100, "state": "idle"}}
                 ]
@@ -28,7 +28,7 @@
         "children": [
           {"type": "GeneralNode", "id": "south_general", "config": {"style": "balanced"},
             "children": [
-              {"type": "ArmyNode", "id": "south_army", "config": {"goal": "advance"},
+              {"type": "ArmyNode", "id": "south_army", "config": {"goal": "advance", "size": 1},
                 "children": [
                   {"type": "UnitNode", "id": "south_unit_1", "config": {"size": 100, "state": "idle"}}
                 ]

--- a/nodes/army.py
+++ b/nodes/army.py
@@ -1,0 +1,57 @@
+"""Army node grouping units and tracking objectives."""
+from __future__ import annotations
+
+from typing import List
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class ArmyNode(SimNode):
+    """Represent an army with a goal and current size.
+
+    Parameters
+    ----------
+    goal:
+        Current objective of the army: ``"advance"``, ``"defend"`` or ``"retreat"``.
+    size:
+        Number of unit groups in the army.
+    """
+
+    def __init__(self, goal: str, size: int = 0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.goal = goal
+        self.size = size
+        self.on_event("unit_engaged", self._handle_unit_event)
+        self.on_event("unit_routed", self._handle_unit_event)
+
+    # ------------------------------------------------------------------
+    def _handle_unit_event(self, origin: SimNode, event: str, payload: dict) -> None:
+        """Forward unit events as battlefield reports and adjust size."""
+
+        if event == "unit_routed":
+            loss = payload.get("loss", 1)
+            self.size = max(0, self.size - loss)
+
+        self.emit("battlefield_event", {"type": event, **payload}, direction="up")
+
+    # ------------------------------------------------------------------
+    def change_goal(self, new_goal: str) -> None:
+        """Update the army's goal and emit ``goal_changed``."""
+
+        previous = self.goal
+        self.goal = new_goal
+        self.emit(
+            "goal_changed",
+            {"previous": previous, "goal": new_goal},
+            direction="down",
+        )
+
+    # ------------------------------------------------------------------
+    def get_units(self) -> List[SimNode]:
+        """Return direct child nodes considered units."""
+
+        return [c for c in self.children if c.__class__.__name__ == "UnitNode"]
+
+
+register_node_type("ArmyNode", ArmyNode)

--- a/tests/test_army_node.py
+++ b/tests/test_army_node.py
@@ -1,0 +1,40 @@
+from core.simnode import SimNode
+from nodes.army import ArmyNode
+
+
+def test_goal_change_and_unit_listing():
+    army = ArmyNode(goal="defend", size=0)
+    events: list[dict] = []
+    army.on_event("goal_changed", lambda _o, _e, payload: events.append(payload))
+
+    army.change_goal("advance")
+
+    assert army.goal == "advance"
+    assert events[0]["previous"] == "defend"
+    assert events[0]["goal"] == "advance"
+
+    class UnitNode(SimNode):
+        pass
+
+    unit = UnitNode(name="unit")
+    army.add_child(unit)
+
+    assert army.get_units() == [unit]
+
+
+def test_unit_events_update_size_and_emit_report():
+    root = SimNode("root")
+    army = ArmyNode(goal="advance", size=1, parent=root)
+
+    class UnitNode(SimNode):
+        pass
+
+    unit = UnitNode(parent=army)
+
+    reports: list[dict] = []
+    root.on_event("battlefield_event", lambda _o, _e, payload: reports.append(payload))
+
+    unit.emit("unit_routed", {}, direction="up")
+
+    assert army.size == 0
+    assert reports[0]["type"] == "unit_routed"


### PR DESCRIPTION
## Summary
- implement ArmyNode to group units, track goal and size, and report unit events up the chain
- document ArmyNode parameters and mark roadmap milestone complete
- extend war simulation example configuration with initial army sizes

## Testing
- `PYTHONPATH=. python tools/generate_param_docs.py`
- `pytest tests/test_army_node.py tests/test_general_node.py tests/test_nation_node.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f399d83083308c3f5714048cc325