### PR TITLE
Add UnitNode for war simulation

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -10,7 +10,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **NationNode** – Holds moral, capital position and references to generals and armies. Emits `moral_changed` and `capital_captured`.
 - [x] **GeneralNode** – Stores tactical style (aggressive/defensive/balanced) and owns one or more armies. Listens to partial battlefield events due to fog of war.
 - [x] **ArmyNode** – Groups `UnitNode`s, tracks goal (advance, defend, retreat) and current size. Interfaces with Movement and Combat systems.
-- [ ] **UnitNode** – Represents ~100 soldiers with state (moving, fighting, fleeing) and attributes such as speed and morale. Emits `unit_engaged` and `unit_routed`.
+- [x] **UnitNode** – Represents ~100 soldiers with state (moving, fighting, fleeing) and attributes such as speed and morale. Emits `unit_engaged` and `unit_routed`.
 - [ ] **TerrainNode** – Defines map tiles: plain, forest, hill. Influences movement speed and combat bonuses.
 
 ## Global Systems

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -151,6 +151,16 @@
 | velocity | List[float] | None | None |  Initial velocity in meters per second. Defaults to ``[0.0, 0.0]``. |
 | kwargs | _empty |  |  |
 
+### UnitNode
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| size | int | 100 | Number of soldiers in the unit. |
+| state | str | 'idle' | Current state of the unit: ``"idle"``, ``"moving"``, ``"fighting"`` or ``"fleeing"``. |
+| speed | float | 1.0 | Movement speed of the unit. |
+| morale | int | 100 | Morale value of the unit. |
+| kwargs | _empty |  |  |
+
 ### WarehouseNode
 
 | Parameter | Type | Default | Description |

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -1,36 +1,123 @@
 {
   "war_world": {
     "type": "WorldNode",
-    "config": {"width": 100, "height": 50, "seed": 1},
+    "config": {
+      "width": 100,
+      "height": 50,
+      "seed": 1
+    },
     "children": [
-      {"type": "TimeSystem", "id": "time"},
-      {"type": "TerrainNode", "id": "terrain", "config": {
-        "tiles": [
-          ["plain", "plain", "plain", "plain", "plain"],
-          ["plain", "plain", "plain", "plain", "plain"],
-          ["plain", "plain", "plain", "plain", "plain"]
-        ]
-      }},
-      {"type": "NationNode", "id": "north", "config": {"capital_position": [5, 25], "morale": 100},
+      {
+        "type": "TimeSystem",
+        "id": "time"
+      },
+      {
+        "type": "TerrainNode",
+        "id": "terrain",
+        "config": {
+          "tiles": [
+            [
+              "plain",
+              "plain",
+              "plain",
+              "plain",
+              "plain"
+            ],
+            [
+              "plain",
+              "plain",
+              "plain",
+              "plain",
+              "plain"
+            ],
+            [
+              "plain",
+              "plain",
+              "plain",
+              "plain",
+              "plain"
+            ]
+          ]
+        }
+      },
+      {
+        "type": "NationNode",
+        "id": "north",
+        "config": {
+          "capital_position": [
+            5,
+            25
+          ],
+          "morale": 100
+        },
         "children": [
-          {"type": "GeneralNode", "id": "north_general", "config": {"style": "balanced"},
+          {
+            "type": "GeneralNode",
+            "id": "north_general",
+            "config": {
+              "style": "balanced"
+            },
             "children": [
-              {"type": "ArmyNode", "id": "north_army", "config": {"goal": "advance", "size": 1},
+              {
+                "type": "ArmyNode",
+                "id": "north_army",
+                "config": {
+                  "goal": "advance",
+                  "size": 1
+                },
                 "children": [
-                  {"type": "UnitNode", "id": "north_unit_1", "config": {"size": 100, "state": "idle"}}
+                  {
+                    "type": "UnitNode",
+                    "id": "north_unit_1",
+                    "config": {
+                      "size": 100,
+                      "state": "idle",
+                      "speed": 1.0,
+                      "morale": 100
+                    }
+                  }
                 ]
               }
             ]
           }
         ]
       },
-      {"type": "NationNode", "id": "south", "config": {"capital_position": [95, 25], "morale": 100},
+      {
+        "type": "NationNode",
+        "id": "south",
+        "config": {
+          "capital_position": [
+            95,
+            25
+          ],
+          "morale": 100
+        },
         "children": [
-          {"type": "GeneralNode", "id": "south_general", "config": {"style": "balanced"},
+          {
+            "type": "GeneralNode",
+            "id": "south_general",
+            "config": {
+              "style": "balanced"
+            },
             "children": [
-              {"type": "ArmyNode", "id": "south_army", "config": {"goal": "advance", "size": 1},
+              {
+                "type": "ArmyNode",
+                "id": "south_army",
+                "config": {
+                  "goal": "advance",
+                  "size": 1
+                },
                 "children": [
-                  {"type": "UnitNode", "id": "south_unit_1", "config": {"size": 100, "state": "idle"}}
+                  {
+                    "type": "UnitNode",
+                    "id": "south_unit_1",
+                    "config": {
+                      "size": 100,
+                      "state": "idle",
+                      "speed": 1.0,
+                      "morale": 100
+                    }
+                  }
                 ]
               }
             ]

--- a/nodes/unit.py
+++ b/nodes/unit.py
@@ -1,0 +1,53 @@
+"""Unit node representing a group of soldiers."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class UnitNode(SimNode):
+    """Represent a unit group with morale, speed and state.
+
+    Parameters
+    ----------
+    size:
+        Number of soldiers in this unit.
+    state:
+        Current state of the unit: ``"idle"``, ``"moving"``, ``"fighting"`` or ``"fleeing"``.
+    speed:
+        Movement speed of the unit.
+    morale:
+        Morale value of the unit.
+    """
+
+    def __init__(
+        self,
+        size: int = 100,
+        state: str = "idle",
+        speed: float = 1.0,
+        morale: int = 100,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.size = size
+        self.state = state
+        self.speed = speed
+        self.morale = morale
+
+    # ------------------------------------------------------------------
+    def engage(self, enemy: str | SimNode | None = None) -> None:
+        """Set state to ``fighting`` and emit ``unit_engaged``."""
+
+        self.state = "fighting"
+        payload = {"enemy": enemy} if enemy is not None else {}
+        self.emit("unit_engaged", payload, direction="up")
+
+    # ------------------------------------------------------------------
+    def route(self, loss: int = 1) -> None:
+        """Set state to ``fleeing`` and emit ``unit_routed`` with *loss*."""
+
+        self.state = "fleeing"
+        self.emit("unit_routed", {"loss": loss}, direction="up")
+
+
+register_node_type("UnitNode", UnitNode)

--- a/tests/test_unit_node.py
+++ b/tests/test_unit_node.py
@@ -1,0 +1,20 @@
+from core.simnode import SimNode
+from nodes.unit import UnitNode
+
+
+def test_engage_and_route_events():
+    root = SimNode("root")
+    unit = UnitNode(parent=root)
+    events: list[tuple[str, dict]] = []
+    root.on_event("unit_engaged", lambda _o, _e, p: events.append(("engaged", p)))
+    root.on_event("unit_routed", lambda _o, _e, p: events.append(("routed", p)))
+
+    unit.engage(enemy="enemy_unit")
+    assert unit.state == "fighting"
+    assert events[0][0] == "engaged"
+    assert events[0][1]["enemy"] == "enemy_unit"
+
+    unit.route()
+    assert unit.state == "fleeing"
+    assert events[1][0] == "routed"
+    assert events[1][1]["loss"] == 1


### PR DESCRIPTION
## Summary
- implement UnitNode with state, speed, morale and combat events
- document UnitNode parameters and mark roadmap item complete
- enrich war simulation sample config and add UnitNode test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f4f7dd54833080b557d625e83407