### PR TITLE
Add TerrainNode for map tiles

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -11,7 +11,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **GeneralNode** – Stores tactical style (aggressive/defensive/balanced) and owns one or more armies. Listens to partial battlefield events due to fog of war.
 - [x] **ArmyNode** – Groups `UnitNode`s, tracks goal (advance, defend, retreat) and current size. Interfaces with Movement and Combat systems.
 - [x] **UnitNode** – Represents ~100 soldiers with state (moving, fighting, fleeing) and attributes such as speed and morale. Emits `unit_engaged` and `unit_routed`.
-- [ ] **TerrainNode** – Defines map tiles: plain, forest, hill. Influences movement speed and combat bonuses.
+- [x] **TerrainNode** – Defines map tiles: plain, forest, hill. Influences movement speed and combat bonuses.
 
 ## Global Systems
 - [ ] **TimeSystem extension** – Support accelerated and real‑time modes for war scenarios.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -143,6 +143,15 @@
 | height | int | None | None |  |
 | kwargs | _empty |  |  |
 
+### TerrainNode
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| tiles | List[List[str]] |  | Two-dimensional grid of terrain types. |
+| speed_modifiers | Optional[Dict[str, float]] | None | Mapping of terrain type to movement speed modifier. |
+| combat_bonuses | Optional[Dict[str, int]] | None | Mapping of terrain type to combat bonus value. |
+| kwargs | _empty |  |  |
+
 ### TransformNode
 
 | Parameter | Type | Default | Description |

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -18,22 +18,22 @@
           "tiles": [
             [
               "plain",
-              "plain",
-              "plain",
-              "plain",
-              "plain"
-            ],
-            [
-              "plain",
-              "plain",
-              "plain",
+              "forest",
+              "hill",
               "plain",
               "plain"
             ],
             [
               "plain",
+              "forest",
+              "hill",
               "plain",
+              "plain"
+            ],
+            [
               "plain",
+              "forest",
+              "hill",
               "plain",
               "plain"
             ]

--- a/nodes/terrain.py
+++ b/nodes/terrain.py
@@ -1,0 +1,73 @@
+"""Terrain node defining map tiles and modifiers."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class TerrainNode(SimNode):
+    """Store terrain tiles and provide movement/combat modifiers.
+
+    Parameters
+    ----------
+    tiles:
+        Two-dimensional list describing the terrain type at each map
+        position.
+    speed_modifiers:
+        Optional mapping of terrain type to movement speed modifier.
+    combat_bonuses:
+        Optional mapping of terrain type to combat bonus value.
+    """
+
+    def __init__(
+        self,
+        tiles: List[List[str]],
+        speed_modifiers: Optional[Dict[str, float]] | None = None,
+        combat_bonuses: Optional[Dict[str, int]] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.tiles = tiles
+        self.height = len(tiles)
+        self.width = len(tiles[0]) if tiles else 0
+        self.speed_modifiers = speed_modifiers or {
+            "plain": 1.0,
+            "forest": 0.7,
+            "hill": 0.9,
+        }
+        self.combat_bonuses = combat_bonuses or {
+            "plain": 0,
+            "forest": 1,
+            "hill": 2,
+        }
+
+    # ------------------------------------------------------------------
+    def get_tile(self, x: int, y: int) -> str | None:
+        """Return the terrain type at ``(x, y)`` or ``None`` if out of bounds."""
+
+        if 0 <= y < self.height and 0 <= x < self.width:
+            return self.tiles[y][x]
+        return None
+
+    # ------------------------------------------------------------------
+    def get_speed_modifier(self, x: int, y: int) -> float:
+        """Return movement speed modifier for tile at ``(x, y)``."""
+
+        terrain = self.get_tile(x, y)
+        if terrain is None:
+            return 1.0
+        return self.speed_modifiers.get(terrain, 1.0)
+
+    # ------------------------------------------------------------------
+    def get_combat_bonus(self, x: int, y: int) -> int:
+        """Return combat bonus for tile at ``(x, y)``."""
+
+        terrain = self.get_tile(x, y)
+        if terrain is None:
+            return 0
+        return self.combat_bonuses.get(terrain, 0)
+
+
+register_node_type("TerrainNode", TerrainNode)

--- a/tests/test_terrain_node.py
+++ b/tests/test_terrain_node.py
@@ -1,0 +1,23 @@
+from nodes.terrain import TerrainNode
+
+
+def test_tile_lookup_and_modifiers():
+    tiles = [["plain", "forest"], ["hill", "plain"]]
+    terrain = TerrainNode(tiles=tiles)
+
+    assert terrain.get_tile(0, 0) == "plain"
+    assert terrain.get_tile(1, 0) == "forest"
+    assert terrain.get_speed_modifier(1, 0) == 0.7
+    assert terrain.get_combat_bonus(0, 1) == 2
+
+
+def test_custom_modifiers():
+    tiles = [["forest"]]
+    terrain = TerrainNode(
+        tiles=tiles,
+        speed_modifiers={"forest": 0.5},
+        combat_bonuses={"forest": 3},
+    )
+
+    assert terrain.get_speed_modifier(0, 0) == 0.5
+    assert terrain.get_combat_bonus(0, 0) == 3


### PR DESCRIPTION
## Summary
- implement TerrainNode holding terrain tiles with speed and combat modifiers
- document TerrainNode parameters and mark roadmap milestone complete
- provide example terrain layout and tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f61bb8188330b8b2165b66b13ccd