### PR TITLE
Add time scaling to TimeSystem

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -14,7 +14,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **TerrainNode** – Defines map tiles: plain, forest, hill. Influences movement speed and combat bonuses.
 
 ## Global Systems
-- [ ] **TimeSystem extension** – Support accelerated and real‑time modes for war scenarios.
+- [x] **TimeSystem extension** – Support accelerated and real‑time modes for war scenarios.
 - [ ] **MovementSystem** – Moves units each tick toward targets while considering terrain speed modifiers, obstacles and morale penalties. Prepare for future hex‑grid pathfinding (initial version may use square grid).
 - [ ] **CombatSystem** – When opposing units occupy the same tile, resolve combat using unit size, randomness and terrain modifiers. Update unit states and nation morale.
 - [ ] **MoralSystem** – Aggregates morale changes from defeats, general losses and events. Triggers nation collapse at zero morale.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -242,6 +242,7 @@
 | tick_duration | float | 1.0 |  |
 | phase_length | int | 10 |  |
 | start_time | float | 0.0 |  |
+| time_scale | float | 1.0 | Multiplier for elapsed time (``>1`` accelerates). |
 | kwargs | _empty |  |  |
 
 ### WeatherSystem

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -53,6 +53,7 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 ### Temps
 - Simulation basée sur des ticks (1 tick = 1 unité de temps).
 - Possibilité de mode temps réel ou accéléré.
+- Le paramètre `time_scale` du `TimeSystem` ajuste l'accélération du temps.
 
 ### Mouvement
 - Les unités se déplacent à une vitesse dépendant du terrain.

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -9,7 +9,8 @@
     "children": [
       {
         "type": "TimeSystem",
-        "id": "time"
+        "id": "time",
+        "config": {"time_scale": 60}
       },
       {
         "type": "TerrainNode",

--- a/systems/time.py
+++ b/systems/time.py
@@ -6,13 +6,18 @@ from core.plugins import register_node_type
 
 
 class TimeSystem(SystemNode):
-    """Emit a `tick` event based on elapsed time and track the day cycle."""
+    """Emit a `tick` event based on elapsed time and track the day cycle.
+
+    The system supports time scaling to run simulations in real time or at an
+    accelerated pace.
+    """
 
     def __init__(
         self,
         tick_duration: float = 1.0,
         phase_length: int = 10,
         start_time: float = 0.0,
+        time_scale: float = 1.0,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -23,9 +28,10 @@ class TimeSystem(SystemNode):
         self.current_time = start_time  # seconds since start of day
         self._accumulator = 0.0
         self.day_length = 24 * 3600.0
+        self.time_scale = time_scale
 
     def update(self, dt: float) -> None:
-        self._accumulator += dt
+        self._accumulator += dt * self.time_scale
         while self._accumulator >= self.tick_duration:
             self._accumulator -= self.tick_duration
             self.current_tick += 1
@@ -35,6 +41,10 @@ class TimeSystem(SystemNode):
             if new_phase != self.phase:
                 self.phase = new_phase
                 self.emit("phase_changed", {"phase": self.phase}, direction="down")
+
+    def set_time_scale(self, scale: float) -> None:
+        """Set a new time scale to accelerate or slow the simulation."""
+        self.time_scale = scale
 
 
 register_node_type("TimeSystem", TimeSystem)

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -12,6 +12,14 @@ def test_time_system_emits_events():
     assert phases == [1]
 
 
+def test_time_system_time_scale_accelerates():
+    sys = TimeSystem(tick_duration=1.0, time_scale=2.0)
+    ticks = []
+    sys.on_event("tick", lambda e, n, p: ticks.append(p["tick"]))
+    sys.update(0.5)  # scaled to 1.0, triggers a tick
+    assert ticks == [1]
+
+
 def test_economy_buy_success():
     econ = EconomySystem()
     buyer = InventoryNode(items={"money": 10})


### PR DESCRIPTION
## Summary
- allow `TimeSystem` to run in real time or accelerated using a configurable `time_scale`
- document and exemplify the new parameter in specs, parameter inventory, and war simulation config
- mark roadmap step for `TimeSystem` extension complete and add test covering time scaling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f76467248330a2e96a181990ae72