### PR TITLE
feat: add movement system

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -15,7 +15,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 
 ## Global Systems
 - [x] **TimeSystem extension** – Support accelerated and real‑time modes for war scenarios.
-- [ ] **MovementSystem** – Moves units each tick toward targets while considering terrain speed modifiers, obstacles and morale penalties. Prepare for future hex‑grid pathfinding (initial version may use square grid).
+- [x] **MovementSystem** – Moves units each tick toward targets while considering terrain speed modifiers, obstacles and morale penalties. Prepare for future hex‑grid pathfinding (initial version may use square grid).
 - [ ] **CombatSystem** – When opposing units occupy the same tile, resolve combat using unit size, randomness and terrain modifiers. Update unit states and nation morale.
 - [ ] **MoralSystem** – Aggregates morale changes from defeats, general losses and events. Triggers nation collapse at zero morale.
 - [ ] **Event Logging/Visualization System** – Provide clear real‑time or accelerated visualisation; for now log movements and combats, later connect to a dedicated viewer.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -168,6 +168,7 @@
 | state | str | 'idle' | Current state of the unit: ``"idle"``, ``"moving"``, ``"fighting"`` or ``"fleeing"``. |
 | speed | float | 1.0 | Movement speed of the unit. |
 | morale | int | 100 | Morale value of the unit. |
+| target | Optional[List[int]] | None | ``[x, y]`` coordinates the unit is moving toward. |
 | kwargs | _empty |  |  |
 
 ### WarehouseNode
@@ -216,6 +217,14 @@
 | --- | --- | --- | --- |
 | events | Optional[Iterable[str]] | None |  Iterable of event names to log. If ``None``, a default set of common events is used. |
 | logger | Optional[logging.Logger] | None |  Optional :class:`logging.Logger` instance. Defaults to one named after the system. |
+| kwargs | _empty |  |  |
+
+### MovementSystem
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| terrain | Optional[TerrainNode | str] | None | Terrain node or id providing speed modifiers. |
+| obstacles | Optional[List[List[int]]] | None | List of impassable ``[x, y]`` coordinates. |
 | kwargs | _empty |  |  |
 
 ### PygameViewerSystem

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -56,8 +56,10 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 - Le paramètre `time_scale` du `TimeSystem` ajuste l'accélération du temps.
 
 ### Mouvement
-- Les unités se déplacent à une vitesse dépendant du terrain.
-- Gestion simplifiée : chaque tick = déplacement d’un pas en fonction de la vitesse.
+- Les unités se déplacent vers une position cible.
+- La vitesse est affectée par le type de terrain et le moral de l’unité.
+- Les obstacles définis sur la carte sont infranchissables.
+- Implémentation initiale en grille carrée (préparation pour une grille hexagonale ultérieure).
 
 ### Combat
 - Lorsque deux unités ennemies se rencontrent :

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -13,6 +13,11 @@
         "config": {"time_scale": 60}
       },
       {
+        "type": "MovementSystem",
+        "id": "movement",
+        "config": {"terrain": "terrain"}
+      },
+      {
         "type": "TerrainNode",
         "id": "terrain",
         "config": {
@@ -74,8 +79,15 @@
                       "size": 100,
                       "state": "idle",
                       "speed": 1.0,
-                      "morale": 100
-                    }
+                      "morale": 100,
+                      "target": [95, 25]
+                    },
+                    "children": [
+                      {
+                        "type": "TransformNode",
+                        "config": {"position": [5, 25]}
+                      }
+                    ]
                   }
                 ]
               }
@@ -116,8 +128,15 @@
                       "size": 100,
                       "state": "idle",
                       "speed": 1.0,
-                      "morale": 100
-                    }
+                      "morale": 100,
+                      "target": [5, 25]
+                    },
+                    "children": [
+                      {
+                        "type": "TransformNode",
+                        "config": {"position": [95, 25]}
+                      }
+                    ]
                   }
                 ]
               }

--- a/nodes/unit.py
+++ b/nodes/unit.py
@@ -18,6 +18,8 @@ class UnitNode(SimNode):
         Movement speed of the unit.
     morale:
         Morale value of the unit.
+    target:
+        Optional ``[x, y]`` coordinates the unit is moving toward.
     """
 
     def __init__(
@@ -26,6 +28,7 @@ class UnitNode(SimNode):
         state: str = "idle",
         speed: float = 1.0,
         morale: int = 100,
+        target: list[int] | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -33,6 +36,7 @@ class UnitNode(SimNode):
         self.state = state
         self.speed = speed
         self.morale = morale
+        self.target = target
 
     # ------------------------------------------------------------------
     def engage(self, enemy: str | SimNode | None = None) -> None:

--- a/systems/movement.py
+++ b/systems/movement.py
@@ -1,0 +1,113 @@
+"""System to move units toward targets considering terrain and morale."""
+from __future__ import annotations
+
+from math import hypot
+from typing import Iterable, List, Optional
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.unit import UnitNode
+from nodes.terrain import TerrainNode
+from nodes.transform import TransformNode
+
+
+class MovementSystem(SystemNode):
+    """Move units each update toward their target position.
+
+    The movement speed of a unit is affected by the terrain tile modifier and
+    the unit's morale (scaled between ``0`` and ``1``).
+
+    Parameters
+    ----------
+    terrain:
+        Reference to the :class:`TerrainNode` providing tile modifiers. If a
+        string is supplied the node with this id is looked up on first update.
+    obstacles:
+        Optional list of impassable ``[x, y]`` coordinates.
+    """
+
+    def __init__(
+        self,
+        terrain: TerrainNode | str | None = None,
+        obstacles: Optional[List[List[int]]] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._terrain_ref = terrain
+        self.terrain: TerrainNode | None = terrain if isinstance(terrain, TerrainNode) else None
+        self.obstacles = {tuple(o) for o in (obstacles or [])}
+
+    # ------------------------------------------------------------------
+    def _resolve_terrain(self) -> None:
+        if self.terrain is not None:
+            return
+        name = self._terrain_ref if isinstance(self._terrain_ref, str) else None
+        root = self.parent
+        if root is None:
+            return
+        self.terrain = self._find_terrain(root, name)
+
+    def _find_terrain(self, node: SimNode, name: str | None) -> TerrainNode | None:
+        if isinstance(node, TerrainNode) and (name is None or node.name == name):
+            return node
+        for child in node.children:
+            found = self._find_terrain(child, name)
+            if found is not None:
+                return found
+        return None
+
+    # ------------------------------------------------------------------
+    def _iter_units(self, node: SimNode) -> Iterable[UnitNode]:
+        for child in node.children:
+            if isinstance(child, UnitNode):
+                yield child
+            yield from self._iter_units(child)
+
+    # ------------------------------------------------------------------
+    def _get_transform(self, node: SimNode) -> TransformNode | None:
+        if isinstance(node, TransformNode):
+            return node
+        for child in node.children:
+            if isinstance(child, TransformNode):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        self._resolve_terrain()
+        for unit in self._iter_units(self.parent or self):
+            if not hasattr(unit, "target") or unit.target is None:
+                continue
+            transform = self._get_transform(unit)
+            if transform is None:
+                continue
+            tx, ty = transform.position
+            gx, gy = unit.target
+            dx, dy = gx - tx, gy - ty
+            dist = hypot(dx, dy)
+            if dist == 0:
+                unit.state = "idle"
+                continue
+            # compute speed modifiers
+            speed = unit.speed
+            if self.terrain is not None:
+                speed *= self.terrain.get_speed_modifier(int(tx), int(ty))
+            speed *= max(unit.morale, 0) / 100.0
+            step = speed * dt
+            if step <= 0:
+                continue
+            if step >= dist:
+                new_x, new_y = gx, gy
+            else:
+                nx = tx + dx / dist * step
+                ny = ty + dy / dist * step
+                new_x, new_y = nx, ny
+            if (int(round(new_x)), int(round(new_y))) in self.obstacles:
+                continue
+            transform.position[0] = new_x
+            transform.position[1] = new_y
+            unit.state = "moving"
+        super().update(dt)
+
+
+register_node_type("MovementSystem", MovementSystem)

--- a/tests/test_movement_system.py
+++ b/tests/test_movement_system.py
@@ -1,0 +1,32 @@
+from nodes.world import WorldNode
+from nodes.terrain import TerrainNode
+from nodes.unit import UnitNode
+from nodes.transform import TransformNode
+from systems.movement import MovementSystem
+
+
+def test_movement_considers_terrain_and_morale():
+    world = WorldNode()
+    terrain = TerrainNode(tiles=[["forest", "forest"]], speed_modifiers={"forest": 0.5})
+    MovementSystem(parent=world, terrain=terrain)
+    unit = UnitNode(parent=world, speed=1.0, morale=50, target=[1, 0])
+    TransformNode(parent=unit, position=[0.0, 0.0])
+
+    world.update(1.0)
+    transform = next(c for c in unit.children if isinstance(c, TransformNode))
+    assert transform.position[0] == 0.25
+
+    world.update(3.0)
+    assert transform.position[0] == 1.0
+
+
+def test_obstacle_blocks_movement():
+    world = WorldNode()
+    terrain = TerrainNode(tiles=[["plain", "plain"]])
+    MovementSystem(parent=world, terrain=terrain, obstacles=[[1, 0]])
+    unit = UnitNode(parent=world, speed=1.0, morale=100, target=[2, 0])
+    TransformNode(parent=unit, position=[0.0, 0.0])
+
+    world.update(1.0)
+    transform = next(c for c in unit.children if isinstance(c, TransformNode))
+    assert transform.position[0] == 0.0


### PR DESCRIPTION
## Summary
- add MovementSystem moving units toward targets with terrain and morale modifiers
- allow UnitNode to define target coordinates
- document MovementSystem and demonstrate usage in war config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f88054f083308030d3e35b48b622