### PR TITLE
Add basic combat system

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -16,7 +16,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 ## Global Systems
 - [x] **TimeSystem extension** – Support accelerated and real‑time modes for war scenarios.
 - [x] **MovementSystem** – Moves units each tick toward targets while considering terrain speed modifiers, obstacles and morale penalties. Prepare for future hex‑grid pathfinding (initial version may use square grid).
-- [ ] **CombatSystem** – When opposing units occupy the same tile, resolve combat using unit size, randomness and terrain modifiers. Update unit states and nation morale.
+- [x] **CombatSystem** – When opposing units occupy the same tile, resolve combat using unit size, randomness and terrain modifiers. Update unit states and nation morale.
 - [ ] **MoralSystem** – Aggregates morale changes from defeats, general losses and events. Triggers nation collapse at zero morale.
 - [ ] **Event Logging/Visualization System** – Provide clear real‑time or accelerated visualisation; for now log movements and combats, later connect to a dedicated viewer.
 

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -219,6 +219,13 @@
 | logger | Optional[logging.Logger] | None |  Optional :class:`logging.Logger` instance. Defaults to one named after the system. |
 | kwargs | _empty |  |  |
 
+### CombatSystem
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| terrain | Optional[TerrainNode | str] | None | Terrain node or id providing combat bonuses. |
+| kwargs | _empty |  |  |
+
 ### MovementSystem
 
 | Parameter | Type | Default | Description |

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -63,8 +63,8 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 
 ### Combat
 - Lorsque deux unités ennemies se rencontrent :
-  - Jet de combat simplifié basé sur la taille de l’unité et un facteur aléatoire.
-  - Le perdant subit une perte de taille et/ou passe en état **fuite**.
+  - Jet de combat simplifié basé sur la taille de l’unité, un bonus de terrain et un facteur aléatoire.
+  - Le perdant subit une perte de taille, voit son moral national réduit et passe en état **fuite**.
 
 ### Moral
 - Chaque nation possède un moral global.

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -18,6 +18,11 @@
         "config": {"terrain": "terrain"}
       },
       {
+        "type": "CombatSystem",
+        "id": "combat",
+        "config": {"terrain": "terrain"}
+      },
+      {
         "type": "TerrainNode",
         "id": "terrain",
         "config": {

--- a/systems/combat.py
+++ b/systems/combat.py
@@ -1,0 +1,125 @@
+"""System resolving combat between opposing units on the same tile."""
+from __future__ import annotations
+
+import random
+from typing import Iterable
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.unit import UnitNode
+from nodes.terrain import TerrainNode
+from nodes.transform import TransformNode
+from nodes.nation import NationNode
+
+
+class CombatSystem(SystemNode):
+    """Resolve combat when opposing units occupy the same tile.
+
+    Parameters
+    ----------
+    terrain:
+        Reference to the :class:`TerrainNode` providing combat bonuses. If a
+        string is supplied the node with this id is looked up on first update.
+    """
+
+    def __init__(self, terrain: TerrainNode | str | None = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._terrain_ref = terrain
+        self.terrain: TerrainNode | None = terrain if isinstance(terrain, TerrainNode) else None
+
+    # ------------------------------------------------------------------
+    def _resolve_terrain(self) -> None:
+        if self.terrain is not None:
+            return
+        name = self._terrain_ref if isinstance(self._terrain_ref, str) else None
+        root = self.parent
+        if root is None:
+            return
+        self.terrain = self._find_terrain(root, name)
+
+    def _find_terrain(self, node: SimNode, name: str | None) -> TerrainNode | None:
+        if isinstance(node, TerrainNode) and (name is None or node.name == name):
+            return node
+        for child in node.children:
+            found = self._find_terrain(child, name)
+            if found is not None:
+                return found
+        return None
+
+    # ------------------------------------------------------------------
+    def _iter_units(self, node: SimNode) -> Iterable[UnitNode]:
+        for child in node.children:
+            if isinstance(child, UnitNode):
+                yield child
+            yield from self._iter_units(child)
+
+    # ------------------------------------------------------------------
+    def _get_transform(self, node: SimNode) -> TransformNode | None:
+        if isinstance(node, TransformNode):
+            return node
+        for child in node.children:
+            if isinstance(child, TransformNode):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _get_nation(self, node: SimNode) -> NationNode | None:
+        cur = node.parent
+        while cur is not None:
+            if isinstance(cur, NationNode):
+                return cur
+            cur = cur.parent
+        return None
+
+    # ------------------------------------------------------------------
+    def _resolve_combat(self, a: UnitNode, b: UnitNode, x: int, y: int) -> None:
+        a.engage(b)
+        b.engage(a)
+        bonus = self.terrain.get_combat_bonus(x, y) if self.terrain is not None else 0
+        strength_a = a.size + bonus + random.randint(0, 10)
+        strength_b = b.size + bonus + random.randint(0, 10)
+        if strength_a == strength_b:
+            return
+        if strength_a > strength_b:
+            loser = b
+        else:
+            loser = a
+        loss = max(1, int(loser.size * 0.1))
+        loser.size = max(0, loser.size - loss)
+        nation = self._get_nation(loser)
+        if nation is not None:
+            nation.change_morale(-loss)
+        loser.route(loss=loss)
+
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        self._resolve_terrain()
+        units = list(self._iter_units(self.parent or self))
+        tiles: dict[tuple[int, int], list[UnitNode]] = {}
+        for unit in units:
+            transform = self._get_transform(unit)
+            if transform is None:
+                continue
+            x, y = int(round(transform.position[0])), int(round(transform.position[1]))
+            tiles.setdefault((x, y), []).append(unit)
+        for (x, y), occupants in tiles.items():
+            if len(occupants) < 2:
+                continue
+            nations: dict[NationNode, list[UnitNode]] = {}
+            for unit in occupants:
+                nation = self._get_nation(unit)
+                if nation is None:
+                    continue
+                nations.setdefault(nation, []).append(unit)
+            if len(nations) < 2:
+                continue
+            nation_units = list(nations.values())
+            for i in range(len(nation_units)):
+                for j in range(i + 1, len(nation_units)):
+                    if not nation_units[i] or not nation_units[j]:
+                        continue
+                    self._resolve_combat(nation_units[i][0], nation_units[j][0], x, y)
+        super().update(dt)
+
+
+register_node_type("CombatSystem", CombatSystem)

--- a/tests/test_combat_system.py
+++ b/tests/test_combat_system.py
@@ -1,0 +1,33 @@
+from nodes.world import WorldNode
+from nodes.terrain import TerrainNode
+from nodes.nation import NationNode
+from nodes.general import GeneralNode
+from nodes.army import ArmyNode
+from nodes.unit import UnitNode
+from nodes.transform import TransformNode
+from systems.combat import CombatSystem
+
+
+def test_combat_routes_losing_unit_and_reduces_morale():
+    world = WorldNode(seed=1)
+    terrain = TerrainNode(tiles=[["plain"]])
+    CombatSystem(parent=world, terrain=terrain)
+
+    north = NationNode(parent=world, morale=100, capital_position=[0, 0])
+    south = NationNode(parent=world, morale=100, capital_position=[1, 0])
+
+    n_gen = GeneralNode(parent=north, style="balanced")
+    n_army = ArmyNode(parent=n_gen, goal="defend", size=1)
+    n_unit = UnitNode(parent=n_army, size=50)
+    TransformNode(parent=n_unit, position=[0, 0])
+
+    s_gen = GeneralNode(parent=south, style="balanced")
+    s_army = ArmyNode(parent=s_gen, goal="advance", size=1)
+    s_unit = UnitNode(parent=s_army, size=100)
+    TransformNode(parent=s_unit, position=[0, 0])
+
+    world.update(1.0)
+
+    assert n_unit.state == "fleeing"
+    assert s_unit.state == "fighting"
+    assert north.morale < 100


### PR DESCRIPTION
## Summary
- implement `CombatSystem` to resolve clashes between units on the same tile using unit size, terrain bonuses and randomness
- include `CombatSystem` in war simulation configuration and document parameters
- mark CombatSystem roadmap task complete and extend war simulation specification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f9b0a9c883309f3359c07064aeb0