### PR TITLE
Add MoralSystem for national morale collapse

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -17,7 +17,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **TimeSystem extension** – Support accelerated and real‑time modes for war scenarios.
 - [x] **MovementSystem** – Moves units each tick toward targets while considering terrain speed modifiers, obstacles and morale penalties. Prepare for future hex‑grid pathfinding (initial version may use square grid).
 - [x] **CombatSystem** – When opposing units occupy the same tile, resolve combat using unit size, randomness and terrain modifiers. Update unit states and nation morale.
-- [ ] **MoralSystem** – Aggregates morale changes from defeats, general losses and events. Triggers nation collapse at zero morale.
+- [x] **MoralSystem** – Aggregates morale changes from defeats, general losses and events. Triggers nation collapse at zero morale.
 - [ ] **Event Logging/Visualization System** – Provide clear real‑time or accelerated visualisation; for now log movements and combats, later connect to a dedicated viewer.
 
 ## Map & Positioning

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -147,9 +147,9 @@
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| tiles | List[List[str]] |  | Two-dimensional grid of terrain types. |
-| speed_modifiers | Optional[Dict[str, float]] | None | Mapping of terrain type to movement speed modifier. |
-| combat_bonuses | Optional[Dict[str, int]] | None | Mapping of terrain type to combat bonus value. |
+| tiles | List[List[str]] |  |  Two-dimensional list describing the terrain type at each map position. |
+| speed_modifiers | Optional[Dict[str, float]] | None | None |  Optional mapping of terrain type to movement speed modifier. |
+| combat_bonuses | Optional[Dict[str, int]] | None | None |  Optional mapping of terrain type to combat bonus value. |
 | kwargs | _empty |  |  |
 
 ### TransformNode
@@ -164,11 +164,11 @@
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| size | int | 100 | Number of soldiers in the unit. |
-| state | str | 'idle' | Current state of the unit: ``"idle"``, ``"moving"``, ``"fighting"`` or ``"fleeing"``. |
-| speed | float | 1.0 | Movement speed of the unit. |
-| morale | int | 100 | Morale value of the unit. |
-| target | Optional[List[int]] | None | ``[x, y]`` coordinates the unit is moving toward. |
+| size | int | 100 |  Number of soldiers in this unit. |
+| state | str | 'idle' |  Current state of the unit: ``"idle"``, ``"moving"``, ``"fighting"`` or ``"fleeing"``. |
+| speed | float | 1.0 |  Movement speed of the unit. |
+| morale | int | 100 |  Morale value of the unit. |
+| target | list[int] | None | None |  Optional ``[x, y]`` coordinates the unit is moving toward. |
 | kwargs | _empty |  |  |
 
 ### WarehouseNode
@@ -198,6 +198,13 @@
 
 ## Systems
 
+### CombatSystem
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| terrain | TerrainNode | str | None | None |  Reference to the :class:`TerrainNode` providing combat bonuses. If a string is supplied the node with this id is looked up on first update. |
+| kwargs | _empty |  |  |
+
 ### DistanceSystem
 
 | Parameter | Type | Default | Description |
@@ -219,19 +226,19 @@
 | logger | Optional[logging.Logger] | None |  Optional :class:`logging.Logger` instance. Defaults to one named after the system. |
 | kwargs | _empty |  |  |
 
-### CombatSystem
+### MoralSystem
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| terrain | Optional[TerrainNode | str] | None | Terrain node or id providing combat bonuses. |
+| collapse_threshold | int | 0 |  Morale value at or below which a nation collapses. |
 | kwargs | _empty |  |  |
 
 ### MovementSystem
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| terrain | Optional[TerrainNode | str] | None | Terrain node or id providing speed modifiers. |
-| obstacles | Optional[List[List[int]]] | None | List of impassable ``[x, y]`` coordinates. |
+| terrain | TerrainNode | str | None | None |  Reference to the :class:`TerrainNode` providing tile modifiers. If a string is supplied the node with this id is looked up on first update. |
+| obstacles | Optional[List[List[int]]] | None | None |  Optional list of impassable ``[x, y]`` coordinates. |
 | kwargs | _empty |  |  |
 
 ### PygameViewerSystem
@@ -258,7 +265,7 @@
 | tick_duration | float | 1.0 |  |
 | phase_length | int | 10 |  |
 | start_time | float | 0.0 |  |
-| time_scale | float | 1.0 | Multiplier for elapsed time (``>1`` accelerates). |
+| time_scale | float | 1.0 |  |
 | kwargs | _empty |  |  |
 
 ### WeatherSystem

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -68,6 +68,7 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 
 ### Moral
 - Chaque nation possède un moral global.
+- Un `MoralSystem` agrège les variations de moral et émet `nation_collapsed` quand il atteint zéro.
 - Le moral baisse lorsque :
   - Une armée subit une lourde défaite.
   - Un général est battu ou tué.

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -10,17 +10,27 @@
       {
         "type": "TimeSystem",
         "id": "time",
-        "config": {"time_scale": 60}
+        "config": {
+          "time_scale": 60
+        }
       },
       {
         "type": "MovementSystem",
         "id": "movement",
-        "config": {"terrain": "terrain"}
+        "config": {
+          "terrain": "terrain"
+        }
       },
       {
         "type": "CombatSystem",
         "id": "combat",
-        "config": {"terrain": "terrain"}
+        "config": {
+          "terrain": "terrain"
+        }
+      },
+      {
+        "type": "MoralSystem",
+        "id": "moral"
       },
       {
         "type": "TerrainNode",
@@ -85,12 +95,20 @@
                       "state": "idle",
                       "speed": 1.0,
                       "morale": 100,
-                      "target": [95, 25]
+                      "target": [
+                        95,
+                        25
+                      ]
                     },
                     "children": [
                       {
                         "type": "TransformNode",
-                        "config": {"position": [5, 25]}
+                        "config": {
+                          "position": [
+                            5,
+                            25
+                          ]
+                        }
                       }
                     ]
                   }
@@ -134,12 +152,20 @@
                       "state": "idle",
                       "speed": 1.0,
                       "morale": 100,
-                      "target": [5, 25]
+                      "target": [
+                        5,
+                        25
+                      ]
                     },
                     "children": [
                       {
                         "type": "TransformNode",
-                        "config": {"position": [95, 25]}
+                        "config": {
+                          "position": [
+                            95,
+                            25
+                          ]
+                        }
                       }
                     ]
                   }

--- a/systems/moral.py
+++ b/systems/moral.py
@@ -1,0 +1,45 @@
+"""System aggregating morale changes and triggering nation collapse."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.nation import NationNode
+
+
+class MoralSystem(SystemNode):
+    """Track morale of nations and emit collapse when it reaches zero.
+
+    Parameters
+    ----------
+    collapse_threshold:
+        Morale value at or below which a nation collapses.
+    """
+
+    def __init__(self, collapse_threshold: int = 0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.collapse_threshold = collapse_threshold
+        self._morale: Dict[NationNode, int] = {}
+        self._collapsed: set[NationNode] = set()
+
+    # ------------------------------------------------------------------
+    def _iter_nations(self, node: SimNode) -> Iterable[NationNode]:
+        for child in node.children:
+            if isinstance(child, NationNode):
+                yield child
+            yield from self._iter_nations(child)
+
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        root = self.parent or self
+        for nation in self._iter_nations(root):
+            morale = nation.morale
+            self._morale[nation] = morale
+            if morale <= self.collapse_threshold and nation not in self._collapsed:
+                nation.emit("nation_collapsed", {"morale": morale})
+                self._collapsed.add(nation)
+        super().update(dt)
+
+
+register_node_type("MoralSystem", MoralSystem)

--- a/tests/test_moral_system.py
+++ b/tests/test_moral_system.py
@@ -1,0 +1,19 @@
+from nodes.world import WorldNode
+from nodes.nation import NationNode
+from systems.moral import MoralSystem
+
+
+def test_nation_collapses_when_morale_depleted():
+    world = WorldNode()
+    MoralSystem(parent=world)
+    nation = NationNode(parent=world, morale=5, capital_position=[0, 0])
+
+    collapsed = []
+
+    def on_collapsed(origin, event, payload):
+        collapsed.append(payload)
+
+    nation.on_event("nation_collapsed", on_collapsed)
+    nation.change_morale(-5)
+    world.update(1.0)
+    assert collapsed and collapsed[0]["morale"] <= 0


### PR DESCRIPTION
## Summary
- Track morale for each nation and emit `nation_collapsed` when it drops to zero
- Wire the new MoralSystem into the war simulation config and docs
- Document MoralSystem parameters and mark roadmap progress

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0fa876608833087c31dd5a25a580a