### PR TITLE
Add event logging system to war simulation

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -18,7 +18,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **MovementSystem** – Moves units each tick toward targets while considering terrain speed modifiers, obstacles and morale penalties. Prepare for future hex‑grid pathfinding (initial version may use square grid).
 - [x] **CombatSystem** – When opposing units occupy the same tile, resolve combat using unit size, randomness and terrain modifiers. Update unit states and nation morale.
 - [x] **MoralSystem** – Aggregates morale changes from defeats, general losses and events. Triggers nation collapse at zero morale.
-- [ ] **Event Logging/Visualization System** – Provide clear real‑time or accelerated visualisation; for now log movements and combats, later connect to a dedicated viewer.
+- [x] **Event Logging/Visualization System** – Provide clear real‑time or accelerated visualisation; for now log movements and combats, later connect to a dedicated viewer.
 
 ## Map & Positioning
 - [ ] **Grid selection** – Start with simple square grid; evaluate hexagonal grid for future upgrade.

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -74,6 +74,11 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
   - Un général est battu ou tué.
 - Si le moral atteint 0 → effondrement, la nation perd.
 
+### Journalisation des événements
+- Un `LoggingSystem` écoute les événements comme `unit_moved`, `combat_occurred`,
+  `unit_engaged` et `unit_routed`.
+- Il consigne ces événements pour une visualisation en temps réel ou accélérée.
+
 ---
 
 ## 4. Conditions de victoire

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -33,6 +33,13 @@
         "id": "moral"
       },
       {
+        "type": "LoggingSystem",
+        "id": "logger",
+        "config": {
+          "events": ["unit_moved", "combat_occurred", "unit_engaged", "unit_routed"]
+        }
+      },
+      {
         "type": "TerrainNode",
         "id": "terrain",
         "config": {

--- a/systems/combat.py
+++ b/systems/combat.py
@@ -81,15 +81,25 @@ class CombatSystem(SystemNode):
         if strength_a == strength_b:
             return
         if strength_a > strength_b:
-            loser = b
+            loser, winner = b, a
         else:
-            loser = a
+            loser, winner = a, b
         loss = max(1, int(loser.size * 0.1))
         loser.size = max(0, loser.size - loss)
         nation = self._get_nation(loser)
         if nation is not None:
             nation.change_morale(-loss)
         loser.route(loss=loss)
+        self.emit(
+            "combat_occurred",
+            {
+                "position": [x, y],
+                "winner": winner.name,
+                "loser": loser.name,
+                "loss": loss,
+            },
+            direction="up",
+        )
 
     # ------------------------------------------------------------------
     def update(self, dt: float) -> None:

--- a/systems/movement.py
+++ b/systems/movement.py
@@ -107,6 +107,11 @@ class MovementSystem(SystemNode):
             transform.position[0] = new_x
             transform.position[1] = new_y
             unit.state = "moving"
+            unit.emit(
+                "unit_moved",
+                {"from": [tx, ty], "to": [new_x, new_y]},
+                direction="up",
+            )
         super().update(dt)
 
 

--- a/tests/test_war_logging.py
+++ b/tests/test_war_logging.py
@@ -1,0 +1,37 @@
+import logging
+import random
+
+from nodes.world import WorldNode
+from nodes.transform import TransformNode
+from nodes.unit import UnitNode
+from nodes.nation import NationNode
+from systems.movement import MovementSystem
+from systems.combat import CombatSystem
+from systems.logger import LoggingSystem
+
+
+def test_unit_movement_logged(caplog):
+    world = WorldNode(name="world")
+    MovementSystem(parent=world)
+    logger_sys = LoggingSystem(parent=world, events=["unit_moved"])
+    unit = UnitNode(name="u1", target=[1, 0], parent=world)
+    TransformNode(position=[0, 0], parent=unit)
+    with caplog.at_level(logging.INFO, logger=logger_sys.logger.name):
+        world.update(1)
+    assert any("unit_moved" in message for message in caplog.messages)
+
+
+def test_combat_logged(caplog):
+    random.seed(0)
+    world = WorldNode(name="world")
+    CombatSystem(parent=world)
+    logger_sys = LoggingSystem(parent=world, events=["combat_occurred"])
+    nation_a = NationNode(name="a", morale=100, capital_position=[0, 0], parent=world)
+    nation_b = NationNode(name="b", morale=100, capital_position=[1, 0], parent=world)
+    unit_a = UnitNode(name="ua", size=20, parent=nation_a)
+    TransformNode(position=[0, 0], parent=unit_a)
+    unit_b = UnitNode(name="ub", size=10, parent=nation_b)
+    TransformNode(position=[0, 0], parent=unit_b)
+    with caplog.at_level(logging.INFO, logger=logger_sys.logger.name):
+        world.update(1)
+    assert any("combat_occurred" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- emit `unit_moved` events in `MovementSystem`
- emit `combat_occurred` events in `CombatSystem`
- integrate `LoggingSystem` into war config and document logging in roadmap and spec
- test movement and combat event logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbec0b608330a1627d1253b63d93