### PR TITLE
Add grid selection to TerrainNode with square and hex support

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -21,7 +21,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **Event Logging/Visualization System** – Provide clear real‑time or accelerated visualisation; for now log movements and combats, later connect to a dedicated viewer.
 
 ## Map & Positioning
-- [ ] **Grid selection** – Start with simple square grid; evaluate hexagonal grid for future upgrade.
+- [x] **Grid selection** – Start with simple square grid; evaluate hexagonal grid for future upgrade.
 - [ ] **Initial placements** – Define starting positions for each nation's capital, generals and armies within the config file.
 - [ ] **Obstacles** – Represent impassable terrain or temporary obstacles (e.g., rivers) in the map data.
 

--- a/docs/specs/project_spec.md
+++ b/docs/specs/project_spec.md
@@ -55,6 +55,8 @@ For modelling the farm and inhabitants:
 - **ResourceProducerNode** – produces a resource every tick consuming optional inputs. Emits `resource_produced`.
 - **AIBehaviorNode** – decides actions based on internal state and events (`need_threshold_reached`, `phase_changed`, etc.).
 - **TransformNode** (optional) – stores position in meters and velocity in meters per second.
+- **TerrainNode** – describes terrain tiles on a square or hex grid with
+  movement and combat modifiers (`grid_type` defaults to ``square``).
 - **AnimalNode** – represents livestock or wildlife with needs and optional resource production. Emits events such as `animal_fed`.
 
 Example usage:
@@ -170,6 +172,13 @@ Steps must be completed in order, each with accompanying unit tests.
 - `on_event` reacts to needs, time and production events.
 - `update` may emit regular commands.
 - Tests for reacting to a need threshold by eating, etc.
+
+#### 4.5 TerrainNode
+- Attributes: `tiles`, optional `grid_type` (``square`` or ``hex``),
+  `speed_modifiers`, `combat_bonuses`.
+- Methods: `get_tile`, `get_speed_modifier`, `get_combat_bonus`,
+  `get_neighbors`.
+- Tests for tile lookup, modifiers and neighbour calculation.
 
 ### Step 5: Global Systems
 #### 5.1 TimeSystem

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -45,6 +45,8 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
   - Plaines → déplacements rapides
   - Forêts → ralentissement, bonus défensif
   - Collines → bonus de visibilité et de défense
+- La grille est contrôlée par le paramètre ``grid_type`` du ``TerrainNode``
+  (``square`` par défaut, ``hex`` prévu pour une future version).
 
 ---
 

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -43,6 +43,7 @@
         "type": "TerrainNode",
         "id": "terrain",
         "config": {
+          "grid_type": "square",
           "tiles": [
             [
               "plain",

--- a/tests/test_terrain_node.py
+++ b/tests/test_terrain_node.py
@@ -21,3 +21,19 @@ def test_custom_modifiers():
 
     assert terrain.get_speed_modifier(0, 0) == 0.5
     assert terrain.get_combat_bonus(0, 0) == 3
+
+
+def test_neighbor_lookup_square_and_hex():
+    tiles = [["plain" for _ in range(3)] for _ in range(3)]
+    square = TerrainNode(tiles=tiles, grid_type="square")
+    hexagon = TerrainNode(tiles=tiles, grid_type="hex")
+
+    assert set(square.get_neighbors(1, 1)) == {(2, 1), (0, 1), (1, 0), (1, 2)}
+    assert set(hexagon.get_neighbors(1, 1)) == {
+        (2, 1),
+        (2, 0),
+        (1, 0),
+        (0, 1),
+        (0, 2),
+        (1, 2),
+    }


### PR DESCRIPTION
## Summary
- allow TerrainNode to choose between square and hex grids via `grid_type`
- expose neighbour lookup for future pathfinding
- document grid selection and mark roadmap item complete

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0fccb8f78833087263285672558dc