### PR TITLE
Add initial placements for war simulation entities

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -22,7 +22,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 
 ## Map & Positioning
 - [x] **Grid selection** – Start with simple square grid; evaluate hexagonal grid for future upgrade.
-- [ ] **Initial placements** – Define starting positions for each nation's capital, generals and armies within the config file.
+- [x] **Initial placements** – Define starting positions for each nation's capital, generals and armies within the config file.
 - [ ] **Obstacles** – Represent impassable terrain or temporary obstacles (e.g., rivers) in the map data.
 
 ## Behaviour & AI

--- a/docs/specs/project_spec.md
+++ b/docs/specs/project_spec.md
@@ -54,7 +54,7 @@ For modelling the farm and inhabitants:
 - **NeedNode** – represents a need (hunger, fatigue). Holds current value, thresholds and change rates. Emits `need_threshold_reached` and `need_satisfied`.
 - **ResourceProducerNode** – produces a resource every tick consuming optional inputs. Emits `resource_produced`.
 - **AIBehaviorNode** – decides actions based on internal state and events (`need_threshold_reached`, `phase_changed`, etc.).
-- **TransformNode** (optional) – stores position in meters and velocity in meters per second.
+- **TransformNode** (optional) – stores position in meters and velocity in meters per second. Used to define initial placements for capitals, generals, armies and units in scenarios like the war simulation.
 - **TerrainNode** – describes terrain tiles on a square or hex grid with
   movement and combat modifiers (`grid_type` defaults to ``square``).
 - **AnimalNode** – represents livestock or wildlife with needs and optional resource production. Emits events such as `animal_fed`.

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -48,6 +48,11 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 - La grille est contrôlée par le paramètre ``grid_type`` du ``TerrainNode``
   (``square`` par défaut, ``hex`` prévu pour une future version).
 
+### Positionnement initial
+- Chaque nation définit une ``capital_position`` dans la configuration.
+- Les ``GeneralNode`` et ``ArmyNode`` reçoivent un ``TransformNode`` indiquant leur position de départ.
+- Les ``UnitNode`` disposent également d'un ``TransformNode`` pour être placées sur la carte.
+
 ---
 
 ## 3. Systèmes globaux

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -88,6 +88,15 @@
             },
             "children": [
               {
+                "type": "TransformNode",
+                "config": {
+                  "position": [
+                    5,
+                    25
+                  ]
+                }
+              },
+              {
                 "type": "ArmyNode",
                 "id": "north_army",
                 "config": {
@@ -95,6 +104,15 @@
                   "size": 1
                 },
                 "children": [
+                  {
+                    "type": "TransformNode",
+                    "config": {
+                      "position": [
+                        5,
+                        25
+                      ]
+                    }
+                  },
                   {
                     "type": "UnitNode",
                     "id": "north_unit_1",
@@ -145,6 +163,15 @@
             },
             "children": [
               {
+                "type": "TransformNode",
+                "config": {
+                  "position": [
+                    95,
+                    25
+                  ]
+                }
+              },
+              {
                 "type": "ArmyNode",
                 "id": "south_army",
                 "config": {
@@ -152,6 +179,15 @@
                   "size": 1
                 },
                 "children": [
+                  {
+                    "type": "TransformNode",
+                    "config": {
+                      "position": [
+                        95,
+                        25
+                      ]
+                    }
+                  },
                   {
                     "type": "UnitNode",
                     "id": "south_unit_1",


### PR DESCRIPTION
## Summary
- give generals and armies starting positions via TransformNode in the war config
- document how capitals, generals, armies and units are placed on the map
- check off roadmap item for initial placements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0fe0bbe44833092eeb67a4d20738d