### PR TITLE
feat: implement general decision making AI

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -26,7 +26,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **Obstacles** – Represent impassable terrain or temporary obstacles (e.g., rivers) in the map data.
 
 ## Behaviour & AI
-- [ ] **General decision making** – Implement simple AI reacting to partial information, moral status and objectives.
+- [x] **General decision making** – Implement simple AI reacting to partial information, moral status and objectives.
 - [ ] **Unit behaviour** – Units move toward targets, avoid obstacles, engage enemies or retreat when morale is low.
 - [ ] **Surprise maneuvers** – Allow generals to attempt flanking moves with a success probability.
 

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -25,6 +25,7 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 - Commande une ou plusieurs armées.
 - Caractéristique principale : **style tactique** (agressif, défensif, équilibré).
 - Reçoit les informations partielles du champ de bataille (brouillard de guerre).
+- Ajuste les objectifs des armées selon ces rapports et le moral national.
 
 ### Armée
 - Regroupe un ensemble d’unités.

--- a/nodes/general.py
+++ b/nodes/general.py
@@ -36,4 +36,55 @@ class GeneralNode(SimNode):
         return [c for c in self.children if c.__class__.__name__ == "ArmyNode"]
 
 
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        """Update child nodes then run simple decision logic."""
+
+        super().update(dt)
+        self._decide()
+
+    # ------------------------------------------------------------------
+    def _decide(self) -> None:
+        """Adjust armies' goals based on latest reports and nation morale.
+
+        The general uses only the most recent battlefield report to make a
+        decision. Thresholds depend on ``style``:
+
+        ``aggressive`` -> defend below 40 morale, retreat below 20.
+        ``balanced``   -> defend below 60 morale, retreat below 30.
+        ``defensive``  -> defend below 80 morale, retreat below 50.
+        """
+
+        if not self.reports:
+            return
+
+        nation = self.parent if self.parent and self.parent.__class__.__name__ == "NationNode" else None
+        morale = getattr(nation, "morale", 0)
+        thresholds = {
+            "aggressive": {"defend": 40, "retreat": 20},
+            "balanced": {"defend": 60, "retreat": 30},
+            "defensive": {"defend": 80, "retreat": 50},
+        }.get(self.style, {"defend": 60, "retreat": 30})
+
+        last = self.reports[-1]
+        defend_th = thresholds["defend"]
+        retreat_th = thresholds["retreat"]
+
+        if last.get("type") == "unit_routed":
+            goal = "retreat" if morale < retreat_th else "defend"
+        else:
+            if morale < retreat_th:
+                goal = "retreat"
+            elif morale < defend_th:
+                goal = "defend"
+            else:
+                goal = "advance"
+
+        for army in self.get_armies():
+            if getattr(army, "goal", None) != goal:
+                army.change_goal(goal)
+
+        self.reports.clear()
+
+
 register_node_type("GeneralNode", GeneralNode)

--- a/tests/test_general_node.py
+++ b/tests/test_general_node.py
@@ -1,14 +1,11 @@
-from core.simnode import SimNode
 from nodes.general import GeneralNode
+from nodes.army import ArmyNode
+from nodes.nation import NationNode
 
 
 def test_general_records_style_and_reports():
     general = GeneralNode(style="aggressive")
-
-    class ArmyNode(SimNode):
-        pass
-
-    army = ArmyNode(name="army")
+    army = ArmyNode(name="army", goal="advance")
     general.add_child(army)
 
     army.emit("battlefield_event", {"sector": 1})
@@ -16,3 +13,25 @@ def test_general_records_style_and_reports():
     assert general.style == "aggressive"
     assert general.reports[0]["sector"] == 1
     assert general.get_armies() == [army]
+
+
+def test_general_ai_changes_army_goal_based_on_morale_and_reports():
+    nation = NationNode(name="nation", morale=100, capital_position=[0, 0])
+    general = GeneralNode(parent=nation, style="balanced")
+    army = ArmyNode(parent=general, goal="advance", size=1)
+
+    # High morale with no reports keeps goal
+    general.update(0)
+    assert army.goal == "advance"
+
+    # Unit engaged while morale drops -> defend
+    nation.morale = 50
+    army.emit("battlefield_event", {"type": "unit_engaged"})
+    general.update(0)
+    assert army.goal == "defend"
+
+    # Unit routed and very low morale -> retreat
+    nation.morale = 20
+    army.emit("battlefield_event", {"type": "unit_routed"})
+    general.update(0)
+    assert army.goal == "retreat"


### PR DESCRIPTION
## Summary
- add simple decision logic for generals to set army goals based on reports and national morale
- document general AI and check off roadmap item
- test general behaviour under different morale scenarios

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1004e19688330bde32184d106bd09