### PR TITLE
Implement unit retreat behaviour

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -27,7 +27,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 
 ## Behaviour & AI
 - [x] **General decision making** – Implement simple AI reacting to partial information, moral status and objectives.
-- [ ] **Unit behaviour** – Units move toward targets, avoid obstacles, engage enemies or retreat when morale is low.
+- [x] **Unit behaviour** – Units move toward targets, avoid obstacles, engage enemies or retreat when morale is low.
 - [ ] **Surprise maneuvers** – Allow generals to attempt flanking moves with a success probability.
 
 ## Victory Conditions

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -39,6 +39,8 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
   - Se déplacer
   - Combattre
   - Battre en retraite
+- Une unité bat en retraite vers la capitale de sa nation si son **moral**
+  descend sous ``30``.
 
 ### Terrain
 - La carte est divisée en zones : **plaine, forêt, colline**.

--- a/nodes/unit.py
+++ b/nodes/unit.py
@@ -20,6 +20,9 @@ class UnitNode(SimNode):
         Morale value of the unit.
     target:
         Optional ``[x, y]`` coordinates the unit is moving toward.
+    retreat_threshold:
+        Morale value below which the unit will retreat toward its nation's
+        capital.
     """
 
     def __init__(
@@ -29,6 +32,7 @@ class UnitNode(SimNode):
         speed: float = 1.0,
         morale: int = 100,
         target: list[int] | None = None,
+        retreat_threshold: int = 30,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -37,6 +41,7 @@ class UnitNode(SimNode):
         self.speed = speed
         self.morale = morale
         self.target = target
+        self.retreat_threshold = retreat_threshold
 
     # ------------------------------------------------------------------
     def engage(self, enemy: str | SimNode | None = None) -> None:
@@ -51,7 +56,30 @@ class UnitNode(SimNode):
         """Set state to ``fleeing`` and emit ``unit_routed`` with *loss*."""
 
         self.state = "fleeing"
+        home = self._get_home_position()
+        if home is not None:
+            self.target = list(home)
         self.emit("unit_routed", {"loss": loss}, direction="up")
+
+    # ------------------------------------------------------------------
+    def _get_home_position(self) -> list[int] | None:
+        """Return the capital position of the owning nation if available."""
+
+        cur = self.parent
+        while cur is not None:
+            if cur.__class__.__name__ == "NationNode":
+                return getattr(cur, "capital_position", None)
+            cur = cur.parent
+        return None
+
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        """Check morale and initiate retreat if it falls too low."""
+
+        if self.morale < self.retreat_threshold and self.state != "fleeing":
+            # no loss when retreating due to low morale
+            self.route(loss=0)
+        super().update(dt)
 
 
 register_node_type("UnitNode", UnitNode)

--- a/tests/test_unit_node.py
+++ b/tests/test_unit_node.py
@@ -1,5 +1,8 @@
 from core.simnode import SimNode
 from nodes.unit import UnitNode
+from nodes.nation import NationNode
+from nodes.army import ArmyNode
+from nodes.transform import TransformNode
 
 
 def test_engage_and_route_events():
@@ -18,3 +21,16 @@ def test_engage_and_route_events():
     assert unit.state == "fleeing"
     assert events[1][0] == "routed"
     assert events[1][1]["loss"] == 1
+
+
+def test_unit_retreats_when_morale_low():
+    root = SimNode("root")
+    nation = NationNode(parent=root, morale=100, capital_position=[0, 0])
+    army = ArmyNode(parent=nation, goal="advance")
+    unit = UnitNode(parent=army, morale=10, target=[10, 0])
+    TransformNode(parent=unit, position=[5, 0])
+
+    unit.update(0)
+
+    assert unit.state == "fleeing"
+    assert unit.target == [0, 0]


### PR DESCRIPTION
## Summary
- Add morale-driven retreat logic to `UnitNode` and redirect retreating units to their nation's capital
- Document unit retreat behaviour in war simulation spec and mark roadmap task complete
- Test that units automatically retreat when morale drops below threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a101985b5483309188e11aecdf0675