### PR TITLE
Add flanking maneuver option for generals

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -28,7 +28,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 ## Behaviour & AI
 - [x] **General decision making** – Implement simple AI reacting to partial information, moral status and objectives.
 - [x] **Unit behaviour** – Units move toward targets, avoid obstacles, engage enemies or retreat when morale is low.
-- [ ] **Surprise maneuvers** – Allow generals to attempt flanking moves with a success probability.
+- [x] **Surprise maneuvers** – Allow generals to attempt flanking moves with a success probability.
 
 ## Victory Conditions
 - [ ] **Capital capture** – Detect when a sufficient number of allied units occupy the enemy capital tile.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -78,6 +78,7 @@
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | style | str |  |  Tactical approach of the general: ``"aggressive"``, ``"defensive"`` or ``"balanced"``. |
+| flank_success_chance | float | 0.25 |  Probability that a flanking manoeuvre initiated by the general succeeds. |
 | kwargs | _empty |  |  |
 
 ### HouseNode

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -26,11 +26,15 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 - Caractéristique principale : **style tactique** (agressif, défensif, équilibré).
 - Reçoit les informations partielles du champ de bataille (brouillard de guerre).
 - Ajuste les objectifs des armées selon ces rapports et le moral national.
+- Peut tenter une **manœuvre de flanc** avec une probabilité de succès
+  configurable (`flank_success_chance`, 25 % par défaut). En cas de
+  réussite, l’armée ciblée change son objectif en ``flank``.
 
 ### Armée
 - Regroupe un ensemble d’unités.
 - Caractéristique principale : **taille** (nombre d’unités).
-- Objectif : avancer vers le camp adverse ou exécuter les ordres du général.
+- Objectif : avancer vers le camp adverse, flanquer, défendre ou battre en
+  retraite selon les ordres du général.
 
 ### Unité
 - Représente un petit groupe de soldats (ex. 100 hommes = 1 unité).

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -89,7 +89,8 @@
             "type": "GeneralNode",
             "id": "north_general",
             "config": {
-              "style": "balanced"
+              "style": "balanced",
+              "flank_success_chance": 0.25
             },
             "children": [
               {
@@ -164,7 +165,8 @@
             "type": "GeneralNode",
             "id": "south_general",
             "config": {
-              "style": "balanced"
+              "style": "balanced",
+              "flank_success_chance": 0.25
             },
             "children": [
               {

--- a/nodes/army.py
+++ b/nodes/army.py
@@ -13,7 +13,8 @@ class ArmyNode(SimNode):
     Parameters
     ----------
     goal:
-        Current objective of the army: ``"advance"``, ``"defend"`` or ``"retreat"``.
+        Current objective of the army: ``"advance"``, ``"defend"``, ``"retreat"``
+        or ``"flank"``.
     size:
         Number of unit groups in the army.
     """

--- a/nodes/general.py
+++ b/nodes/general.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import List, Dict
+import random
 
 from core.simnode import SimNode
 from core.plugins import register_node_type
@@ -15,11 +16,14 @@ class GeneralNode(SimNode):
     style:
         Tactical approach of the general: ``"aggressive"``, ``"defensive"``
         or ``"balanced"``.
+    flank_success_chance:
+        Probability in ``[0, 1]`` that a flanking manoeuvre succeeds.
     """
 
-    def __init__(self, style: str, **kwargs) -> None:
+    def __init__(self, style: str, flank_success_chance: float = 0.25, **kwargs) -> None:
         super().__init__(**kwargs)
         self.style = style
+        self.flank_success_chance = flank_success_chance
         self.reports: List[Dict] = []
         self.on_event("battlefield_event", self._record_report)
 
@@ -34,6 +38,19 @@ class GeneralNode(SimNode):
         """Return direct child nodes considered armies."""
 
         return [c for c in self.children if c.__class__.__name__ == "ArmyNode"]
+
+    # ------------------------------------------------------------------
+    def attempt_flank(self, army: SimNode) -> bool:
+        """Attempt a flanking manoeuvre with *army*.
+
+        Returns ``True`` if the manoeuvre succeeds and the army's goal is
+        changed to ``"flank"``.
+        """
+
+        success = random.random() < self.flank_success_chance
+        if success:
+            army.change_goal("flank")
+        return success
 
 
     # ------------------------------------------------------------------

--- a/tests/test_general_node.py
+++ b/tests/test_general_node.py
@@ -35,3 +35,18 @@ def test_general_ai_changes_army_goal_based_on_morale_and_reports():
     army.emit("battlefield_event", {"type": "unit_routed"})
     general.update(0)
     assert army.goal == "retreat"
+
+
+def test_general_attempts_flank_with_probability():
+    general = GeneralNode(style="balanced", flank_success_chance=1.0)
+    army = ArmyNode(parent=general, goal="advance", size=1)
+
+    # Guaranteed success
+    assert general.attempt_flank(army) is True
+    assert army.goal == "flank"
+
+    # Guaranteed failure
+    other_army = ArmyNode(parent=general, goal="advance", size=1)
+    general.flank_success_chance = 0.0
+    assert general.attempt_flank(other_army) is False
+    assert other_army.goal == "advance"


### PR DESCRIPTION
## Summary
- allow generals to attempt flanking maneuvers with configurable success chance
- document flanking behavior and parameter
- mark surprise maneuvers roadmap item complete

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a102a9f3ec83308cc31ca22ecb7e12