### PR TITLE
Add capital capture victory system

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -31,7 +31,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 - [x] **Surprise maneuvers** – Allow generals to attempt flanking moves with a success probability.
 
 ## Victory Conditions
-- [ ] **Capital capture** – Detect when a sufficient number of allied units occupy the enemy capital tile.
+- [x] **Capital capture** – Detect when a sufficient number of allied units occupy the enemy capital tile.
 - [ ] **Moral collapse** – End simulation if a nation's morale reaches zero.
 
 ## Visualization Enhancements (Later Iterations)

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -46,7 +46,7 @@
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| goal | str |  |  Current objective of the army: ``"advance"``, ``"defend"`` or ``"retreat"``. |
+| goal | str |  |  Current objective of the army: ``"advance"``, ``"defend"``, ``"retreat"`` or ``"flank"``. |
 | size | int | 0 |  Number of unit groups in the army. |
 | kwargs | _empty |  |  |
 
@@ -78,7 +78,7 @@
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | style | str |  |  Tactical approach of the general: ``"aggressive"``, ``"defensive"`` or ``"balanced"``. |
-| flank_success_chance | float | 0.25 |  Probability that a flanking manoeuvre initiated by the general succeeds. |
+| flank_success_chance | float | 0.25 |  Probability in ``[0, 1]`` that a flanking manoeuvre succeeds. |
 | kwargs | _empty |  |  |
 
 ### HouseNode
@@ -151,7 +151,8 @@
 | tiles | List[List[str]] |  |  Two-dimensional list describing the terrain type at each map position. |
 | speed_modifiers | Optional[Dict[str, float]] | None | None |  Optional mapping of terrain type to movement speed modifier. |
 | combat_bonuses | Optional[Dict[str, int]] | None | None |  Optional mapping of terrain type to combat bonus value. |
-| obstacles | Optional[List[List[int]]] | None | None |  Optional list of impassable ``[x, y]`` coordinates. |
+| grid_type | str | 'square' |  ``"square"`` for a 4-neighbour grid or ``"hex"`` for a hexagonal layout. Only the square grid is fully supported for now. |
+| obstacles | Optional[List[List[int]]] | None | None |  Optional list of impassable ``[x, y]`` coordinates such as rivers or mountains. |
 | kwargs | _empty |  |  |
 
 ### TransformNode
@@ -171,6 +172,7 @@
 | speed | float | 1.0 |  Movement speed of the unit. |
 | morale | int | 100 |  Morale value of the unit. |
 | target | list[int] | None | None |  Optional ``[x, y]`` coordinates the unit is moving toward. |
+| retreat_threshold | int | 30 |  Morale value below which the unit will retreat toward its nation's capital. |
 | kwargs | _empty |  |  |
 
 ### WarehouseNode
@@ -240,7 +242,7 @@
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | terrain | TerrainNode | str | None | None |  Reference to the :class:`TerrainNode` providing tile modifiers. If a string is supplied the node with this id is looked up on first update. |
-| obstacles | Optional[List[List[int]]] | None | None |  Additional impassable ``[x, y]`` coordinates merged with terrain obstacles. |
+| obstacles | Optional[List[List[int]]] | None | None |  Optional list of additional impassable ``[x, y]`` coordinates. These are merged with obstacles defined on the :class:`TerrainNode`. |
 | kwargs | _empty |  |  |
 
 ### PygameViewerSystem
@@ -268,6 +270,13 @@
 | phase_length | int | 10 |  |
 | start_time | float | 0.0 |  |
 | time_scale | float | 1.0 |  |
+| kwargs | _empty |  |  |
+
+### VictorySystem
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| capture_unit_threshold | int | 3 |  Number of enemy units required on a capital tile to capture it. |
 | kwargs | _empty |  |  |
 
 ### WeatherSystem

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -99,7 +99,10 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 
 ## 4. Conditions de victoire
 - Une nation gagne si :
-  - **Un nombre suffisant d’unités atteint le camp ennemi** (capture de capitale).
+  - **Un nombre suffisant d’unités atteint le camp ennemi** (capture de
+    capitale). Le ``VictorySystem`` déclenche ``capital_captured`` lorsque au
+    moins ``capture_unit_threshold`` unités ennemies occupent la tuile de la
+    capitale (valeur par défaut : ``3``).
   - **Le moral adverse tombe à 0**.
 
 ---

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -33,6 +33,13 @@
         "id": "moral"
       },
       {
+        "type": "VictorySystem",
+        "id": "victory",
+        "config": {
+          "capture_unit_threshold": 1
+        }
+      },
+      {
         "type": "LoggingSystem",
         "id": "logger",
         "config": {

--- a/systems/victory.py
+++ b/systems/victory.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""System monitoring victory conditions such as capital capture."""
+
+from typing import Iterable
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.nation import NationNode
+from nodes.unit import UnitNode
+from nodes.transform import TransformNode
+
+
+class VictorySystem(SystemNode):
+    """Detect when enemy units capture a nation's capital.
+
+    Parameters
+    ----------
+    capture_unit_threshold:
+        Number of enemy units required on a capital tile to capture it.
+    """
+
+    def __init__(self, capture_unit_threshold: int = 3, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.capture_unit_threshold = capture_unit_threshold
+        self._captured: set[NationNode] = set()
+
+    # ------------------------------------------------------------------
+    def _iter_nations(self, node: SimNode) -> Iterable[NationNode]:
+        for child in node.children:
+            if isinstance(child, NationNode):
+                yield child
+            yield from self._iter_nations(child)
+
+    # ------------------------------------------------------------------
+    def _iter_units(self, node: SimNode) -> Iterable[UnitNode]:
+        for child in node.children:
+            if isinstance(child, UnitNode):
+                yield child
+            yield from self._iter_units(child)
+
+    # ------------------------------------------------------------------
+    def _get_transform(self, node: SimNode) -> TransformNode | None:
+        if isinstance(node, TransformNode):
+            return node
+        for child in node.children:
+            if isinstance(child, TransformNode):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _find_nation(self, node: SimNode) -> NationNode | None:
+        cur = node.parent
+        while cur is not None:
+            if isinstance(cur, NationNode):
+                return cur
+            cur = cur.parent
+        return None
+
+    # ------------------------------------------------------------------
+    def update(self, dt: float) -> None:
+        root = self.parent or self
+        units = list(self._iter_units(root))
+        for nation in self._iter_nations(root):
+            if nation in self._captured:
+                continue
+            cx, cy = nation.capital_position
+            count = 0
+            for unit in units:
+                owner = self._find_nation(unit)
+                if owner is nation:
+                    continue
+                transform = self._get_transform(unit)
+                if transform is None:
+                    continue
+                ux, uy = transform.position
+                if int(round(ux)) == cx and int(round(uy)) == cy:
+                    count += 1
+                    if count >= self.capture_unit_threshold:
+                        nation.capture_capital()
+                        self._captured.add(nation)
+                        break
+        super().update(dt)
+
+
+register_node_type("VictorySystem", VictorySystem)

--- a/tests/test_victory_system.py
+++ b/tests/test_victory_system.py
@@ -1,0 +1,39 @@
+from nodes.world import WorldNode
+from nodes.nation import NationNode
+from nodes.unit import UnitNode
+from nodes.transform import TransformNode
+from systems.victory import VictorySystem
+
+
+def test_capital_captured_when_enough_enemy_units_present():
+    world = WorldNode()
+    VictorySystem(parent=world, capture_unit_threshold=1)
+    attacker = NationNode(parent=world, morale=100, capital_position=[5, 0])
+    defender = NationNode(parent=world, morale=100, capital_position=[0, 0])
+
+    unit = UnitNode(parent=attacker)
+    TransformNode(parent=unit, position=[0, 0])
+
+    events: list[dict] = []
+    defender.on_event("capital_captured", lambda _o, _e, payload: events.append(payload))
+    world.update(1.0)
+    assert events and events[0]["position"] == [0, 0]
+
+
+def test_capture_requires_threshold_number_of_units():
+    world = WorldNode()
+    VictorySystem(parent=world, capture_unit_threshold=2)
+    attacker = NationNode(parent=world, morale=100, capital_position=[5, 0])
+    defender = NationNode(parent=world, morale=100, capital_position=[0, 0])
+
+    unit1 = UnitNode(parent=attacker)
+    TransformNode(parent=unit1, position=[0, 0])
+    events: list[dict] = []
+    defender.on_event("capital_captured", lambda _o, _e, payload: events.append(payload))
+    world.update(1.0)
+    assert not events
+
+    unit2 = UnitNode(parent=attacker)
+    TransformNode(parent=unit2, position=[0, 0])
+    world.update(1.0)
+    assert events and events[0]["position"] == [0, 0]


### PR DESCRIPTION
## Summary
- add VictorySystem to detect enemy units capturing a nation's capital
- expose new system in war simulation config and docs
- document capital capture condition and tick roadmap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a103d622948330846de2cd674face6