### PR TITLE
Handle moral collapse victory condition

### DIFF
--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -32,7 +32,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 
 ## Victory Conditions
 - [x] **Capital capture** – Detect when a sufficient number of allied units occupy the enemy capital tile.
-- [ ] **Moral collapse** – End simulation if a nation's morale reaches zero.
+- [x] **Moral collapse** – End simulation if a nation's morale reaches zero.
 
 ## Visualization Enhancements (Later Iterations)
 - [ ] **Zoom and inspect** – Ability to zoom into specific units or armies.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -273,6 +273,7 @@
 | kwargs | _empty |  |  |
 
 ### VictorySystem
+Monitors capital capture and morale collapse, emitting ``nation_defeated`` when a nation loses.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/specs/war_simulation_spec.md
+++ b/docs/specs/war_simulation_spec.md
@@ -85,6 +85,7 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
 ### Moral
 - Chaque nation possède un moral global.
 - Un `MoralSystem` agrège les variations de moral et émet `nation_collapsed` quand il atteint zéro.
+- Le `VictorySystem` écoute cet événement et réémet `nation_defeated` pour signaler la fin de la simulation.
 - Le moral baisse lorsque :
   - Une armée subit une lourde défaite.
   - Un général est battu ou tué.
@@ -103,7 +104,7 @@ Un **bus d’événements** centralise les interactions (combats, mouvements, or
     capitale). Le ``VictorySystem`` déclenche ``capital_captured`` lorsque au
     moins ``capture_unit_threshold`` unités ennemies occupent la tuile de la
     capitale (valeur par défaut : ``3``).
-  - **Le moral adverse tombe à 0**.
+  - **Le moral adverse tombe à 0** : le `MoralSystem` déclenche `nation_collapsed` et le `VictorySystem` réémet `nation_defeated`.
 
 ---
 

--- a/tests/test_victory_system.py
+++ b/tests/test_victory_system.py
@@ -2,6 +2,7 @@ from nodes.world import WorldNode
 from nodes.nation import NationNode
 from nodes.unit import UnitNode
 from nodes.transform import TransformNode
+from systems.moral import MoralSystem
 from systems.victory import VictorySystem
 
 
@@ -37,3 +38,16 @@ def test_capture_requires_threshold_number_of_units():
     TransformNode(parent=unit2, position=[0, 0])
     world.update(1.0)
     assert events and events[0]["position"] == [0, 0]
+
+
+def test_nation_defeated_on_moral_collapse():
+    world = WorldNode()
+    MoralSystem(parent=world)
+    VictorySystem(parent=world)
+    nation = NationNode(parent=world, morale=1, capital_position=[0, 0])
+
+    defeated: list[dict] = []
+    nation.on_event("nation_defeated", lambda _o, _e, payload: defeated.append(payload))
+    nation.change_morale(-1)
+    world.update(1.0)
+    assert defeated and defeated[0]["reason"] == "moral_collapse"


### PR DESCRIPTION
## Summary
- End simulation when a nation's morale reaches zero by having VictorySystem emit `nation_defeated`
- Document moral collapse victory condition and mark roadmap checklist
- Cover morale collapse with a dedicated unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a104f8bcac8330be5e5e114a1d2704