### PR TITLE
Add war simulation runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ python run_farm.py
 
 The window renders terrain tiles, unit icons and yellow arrows pointing to their movement targets.
 
+For a minimal war scenario showcasing nations, armies and real‑time combat, run:
+
+```
+python run_war.py example/war_simulation_config.json
+```
+
+Pause the simulation with the space bar and close the window or press the close button to exit.
+
 ## Map editor
 
 An interactive map editor is provided in `tools/map_editor.py` to create

--- a/run_war.py
+++ b/run_war.py
@@ -1,0 +1,87 @@
+"""Run the war simulation with a visual Pygame window."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pygame
+
+import config
+
+from core.loader import load_simulation_from_file
+from core.plugins import load_plugins
+from systems.logger import LoggingSystem
+from systems.pygame_viewer import PygameViewerSystem
+from systems.time import TimeSystem
+
+
+# Ensure pygame can be used even when no display is available
+if "DISPLAY" not in os.environ and os.environ.get("SDL_VIDEODRIVER") is None:
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+
+try:
+    pygame.init()
+except pygame.error as exc:  # pragma: no cover - environment-specific
+    print(f"Unable to initialize pygame: {exc}")
+    sys.exit(1)
+
+
+# Load all plugins required for the war simulation
+load_plugins(
+    [
+        "nodes.world",
+        "nodes.nation",
+        "nodes.general",
+        "nodes.army",
+        "nodes.unit",
+        "nodes.terrain",
+        "nodes.transform",
+        "systems.time",
+        "systems.movement",
+        "systems.combat",
+        "systems.moral",
+        "systems.victory",
+        "systems.logger",
+        "systems.pygame_viewer",
+    ]
+)
+
+
+# Load the simulation from a JSON/YAML file
+config_file = sys.argv[1] if len(sys.argv) > 1 else "example/war_simulation_config.json"
+world = load_simulation_from_file(config_file)
+
+
+# Ensure logging and visualization systems are present
+if not any(isinstance(c, LoggingSystem) for c in world.children):
+    LoggingSystem(parent=world)
+
+if not any(isinstance(c, PygameViewerSystem) for c in world.children):
+    PygameViewerSystem(parent=world)
+
+time_system = next((c for c in world.children if isinstance(c, TimeSystem)), None)
+if time_system is not None:
+    time_system.current_time = config.START_TIME
+
+
+FPS = config.FPS
+TIME_SCALE = config.TIME_SCALE
+
+clock = pygame.time.Clock()
+viewer = next((c for c in world.children if isinstance(c, PygameViewerSystem)), None)
+paused = False
+running = True
+while running and pygame.get_init():
+    events = pygame.event.get()
+    for event in events:
+        if event.type == pygame.QUIT:
+            running = False
+        if event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE:
+            paused = not paused
+    if viewer:
+        viewer.process_events(events)
+    dt = clock.tick(FPS) / 1000.0
+    world.update(0 if paused else dt * TIME_SCALE)
+
+pygame.quit()


### PR DESCRIPTION
## Summary
- Add `run_war.py` to launch the war scenario with logging and Pygame visualization
- Document war simulation launch instructions in the README

## Testing
- `pip install flake8 mypy` *(failed: Could not find a version that satisfies the requirement flake8)*
- `mypy nodes systems core run_war.py run_farm.py` *(errors: Name "ValidationError" already defined, etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1087efbec8330b232a81d2edc2413