### PR TITLE
Slow war sim and center viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ python run_farm.py
 
 The window renders terrain tiles, unit icons and yellow arrows pointing to their movement targets.
 
+The viewer opens centered on the battlefield with a compact sidebar so troop
+movement is immediately visible.
+
 For a minimal war scenario showcasing nations, armies and real‑time combat, run:
 
 ```

--- a/config.py
+++ b/config.py
@@ -3,7 +3,8 @@
 # Display settings
 VIEW_WIDTH = 1200
 VIEW_HEIGHT = 720
-PANEL_WIDTH = 320
+# Narrower sidebar for a less obstructed view
+PANEL_WIDTH = 200
 FONT_SIZE = 14
 
 # Map editor defaults
@@ -13,8 +14,9 @@ WORLD_HEIGHT = 144
 BUILDING_SIZE = 10  # in world units
 
 # Simulation timing
+# Use a modest simulation acceleration to keep troop movement visible
 FPS = 24
-TIME_SCALE = 600  # one simulated minute per real second
+TIME_SCALE = 10  # ten simulated seconds per real second
 START_TIME = 8 * 3600 + 0 * 60  # 07:30 in seconds
 
 # Character movement speeds in kilometres per hour

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -11,7 +11,7 @@
         "type": "TimeSystem",
         "id": "time",
         "config": {
-          "time_scale": 60
+          "time_scale": 10
         }
       },
       {
@@ -74,11 +74,7 @@
               "plain"
             ]
           ],
-          "obstacles": [
-            [50, 24],
-            [50, 25],
-            [50, 26]
-          ]
+          "obstacles": []
         }
       },
       {

--- a/run_war.py
+++ b/run_war.py
@@ -70,6 +70,10 @@ TIME_SCALE = config.TIME_SCALE
 
 clock = pygame.time.Clock()
 viewer = next((c for c in world.children if isinstance(c, PygameViewerSystem)), None)
+# Center the view on the world by default
+if viewer:
+    viewer.offset_x = world.width / 2 - viewer.view_width / (2 * viewer.scale)
+    viewer.offset_y = world.height / 2 - viewer.view_height / (2 * viewer.scale)
 paused = False
 running = True
 while running and pygame.get_init():


### PR DESCRIPTION
## Summary
- slow war scenario time scale and slim the sidebar for a clearer view
- remove battlefield obstacles and center the viewer on the world
- document centered view in README

## Testing
- `pip install -r requirements.txt`
- `pip install flake8 mypy` *(fails: Could not find a version that satisfies the requirement flake8)*
- `mypy nodes systems core run_war.py run_farm.py` *(fails: 17 errors in 7 files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a10f694c708330ac65cf0d0dace58e