### PR TITLE
Allow slower speeds in war simulation

### DIFF
--- a/run_war.py
+++ b/run_war.py
@@ -191,7 +191,7 @@ while running and pygame.get_init():
             elif event.key == pygame.K_r:
                 _reset()
             elif event.key == pygame.K_s:
-                TIME_SCALE = max(0.1, TIME_SCALE / 2)
+                TIME_SCALE = max(0.01, TIME_SCALE / 2)
             elif event.key == pygame.K_x:
                 TIME_SCALE = min(100, TIME_SCALE * 2)
             elif paused:


### PR DESCRIPTION
## Summary
- Allow run_war simulation to slow further by decreasing the minimum time scale to 0.01

## Testing
- `flake8` *(fails: command not found)*
- `mypy .` *(fails: Source file found twice under different module names)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a11ca0622c8330a01e2d18685955c1