### PR TITLE
Scale war map and add viewer controls

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,6 +13,11 @@ WORLD_WIDTH = 240
 WORLD_HEIGHT = 144
 BUILDING_SIZE = 10  # in world units
 
+# World scaling (meters per grid unit and default war map size)
+WORLD_SCALE_M = 1.0  # meters per grid unit
+DEFAULT_WORLD_W = 1000  # default world width in grid units
+DEFAULT_WORLD_H = 600   # default world height in grid units
+
 # Simulation timing
 # Use a modest simulation acceleration to keep troop movement visible
 FPS = 24

--- a/docs/checklists/war_simulation_upgrade_checklist.md
+++ b/docs/checklists/war_simulation_upgrade_checklist.md
@@ -15,12 +15,12 @@
 
 ## 1) Map Scale & Distances (km between HQs)
 
-- [ ] **Add** in `config.py`:
-  - [ ] `WORLD_SCALE_M = 1.0`  # meters per grid unit (float)
-  - [ ] `DEFAULT_WORLD_W = 1000`, `DEFAULT_WORLD_H = 600` (example large map)
-- [ ] **Update** `example/war_simulation_config.json` to use larger `width/height` (e.g. 10_000 × 6_000) placing capitals 8–10 km apart.
-- [ ] **Viewer scale bar:** in `systems/pygame_viewer.py`, update the scale bar to compute label using `WORLD_SCALE_M` so the “100 m” annotation remains correct.
-- [ ] **Add runtime zoom/pan keys** (see §10 Controls).
+- [x] **Add** in `config.py`:
+  - [x] `WORLD_SCALE_M = 1.0`  # meters per grid unit (float)
+  - [x] `DEFAULT_WORLD_W = 1000`, `DEFAULT_WORLD_H = 600` (example large map)
+- [x] **Update** `example/war_simulation_config.json` to use larger `width/height` (e.g. 10_000 × 6_000) placing capitals 8–10 km apart.
+- [x] **Viewer scale bar:** in `systems/pygame_viewer.py`, update the scale bar to compute label using `WORLD_SCALE_M` so the “100 m” annotation remains correct.
+- [x] **Add runtime zoom/pan keys** (see §10 Controls).
 
 ---
 

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -2,8 +2,8 @@
   "war_world": {
     "type": "WorldNode",
     "config": {
-      "width": 100,
-      "height": 50,
+      "width": 10000,
+      "height": 6000,
       "seed": 1
     },
     "children": [
@@ -82,8 +82,8 @@
         "id": "north",
         "config": {
           "capital_position": [
-            5,
-            25
+            1000,
+            3000
           ],
           "morale": 100
         },
@@ -100,8 +100,8 @@
                 "type": "TransformNode",
                 "config": {
                   "position": [
-                    5,
-                    25
+                    1000,
+                    3000
                   ]
                 }
               },
@@ -117,8 +117,8 @@
                     "type": "TransformNode",
                     "config": {
                       "position": [
-                        5,
-                        25
+                        1000,
+                        3000
                       ]
                     }
                   },
@@ -131,8 +131,8 @@
                       "speed": 1.0,
                       "morale": 100,
                       "target": [
-                        95,
-                        25
+                        9000,
+                        3000
                       ]
                     },
                     "children": [
@@ -140,8 +140,8 @@
                         "type": "TransformNode",
                         "config": {
                           "position": [
-                            5,
-                            25
+                            1000,
+                            3000
                           ]
                         }
                       }
@@ -158,8 +158,8 @@
         "id": "south",
         "config": {
           "capital_position": [
-            95,
-            25
+            9000,
+            3000
           ],
           "morale": 100
         },
@@ -176,8 +176,8 @@
                 "type": "TransformNode",
                 "config": {
                   "position": [
-                    95,
-                    25
+                    9000,
+                    3000
                   ]
                 }
               },
@@ -193,8 +193,8 @@
                     "type": "TransformNode",
                     "config": {
                       "position": [
-                        95,
-                        25
+                        9000,
+                        3000
                       ]
                     }
                   },
@@ -207,8 +207,8 @@
                       "speed": 1.0,
                       "morale": 100,
                       "target": [
-                        5,
-                        25
+                        1000,
+                        3000
                       ]
                     },
                     "children": [
@@ -216,8 +216,8 @@
                         "type": "TransformNode",
                         "config": {
                           "position": [
-                            95,
-                            25
+                            9000,
+                            3000
                           ]
                         }
                       }

--- a/run_war.py
+++ b/run_war.py
@@ -194,6 +194,28 @@ while running and pygame.get_init():
                 TIME_SCALE = max(0.01, TIME_SCALE / 2)
             elif event.key == pygame.K_x:
                 TIME_SCALE = min(100, TIME_SCALE * 2)
+            elif viewer and event.key == pygame.K_LEFTBRACKET:
+                prev = viewer.scale
+                viewer.scale = max(0.1, viewer.scale * 0.9)
+                cx = viewer.offset_x + viewer.view_width / (2 * prev)
+                cy = viewer.offset_y + viewer.view_height / (2 * prev)
+                viewer.offset_x = cx - viewer.view_width / (2 * viewer.scale)
+                viewer.offset_y = cy - viewer.view_height / (2 * viewer.scale)
+            elif viewer and event.key == pygame.K_RIGHTBRACKET:
+                prev = viewer.scale
+                viewer.scale = viewer.scale * 1.1
+                cx = viewer.offset_x + viewer.view_width / (2 * prev)
+                cy = viewer.offset_y + viewer.view_height / (2 * prev)
+                viewer.offset_x = cx - viewer.view_width / (2 * viewer.scale)
+                viewer.offset_y = cy - viewer.view_height / (2 * viewer.scale)
+            elif viewer and event.key == pygame.K_h:
+                viewer.offset_x -= viewer.view_width * 0.1 / viewer.scale
+            elif viewer and event.key == pygame.K_l:
+                viewer.offset_x += viewer.view_width * 0.1 / viewer.scale
+            elif viewer and event.key == pygame.K_j:
+                viewer.offset_y += viewer.view_height * 0.1 / viewer.scale
+            elif viewer and event.key == pygame.K_k:
+                viewer.offset_y -= viewer.view_height * 0.1 / viewer.scale
             elif paused:
                 if event.key == pygame.K_a:
                     troops_per_nation = max(1, troops_per_nation - 1)

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -331,7 +331,8 @@ class PygameViewerSystem(SystemNode):
                 time_sys = node
 
         # draw a scale bar representing 100 meters
-        scale_length = int(100 * self.scale)
+        grid_units_for_100m = 100 / config.WORLD_SCALE_M
+        scale_length = int(grid_units_for_100m * self.scale)
         bar_y = self.view_height - 20
         pygame.draw.line(self.screen, (255, 255, 255), (10, bar_y), (10 + scale_length, bar_y), 2)
         label = self.font.render("100 m", True, (255, 255, 255))
@@ -359,6 +360,8 @@ class PygameViewerSystem(SystemNode):
         lines.append("Controls:")
         lines.append(" Space: pause/resume")
         lines.append(" +/- : change speed")
+        lines.append(" [: zoom out, ]: zoom in")
+        lines.append(" H/J/K/L: pan view")
         lines.extend(self.extra_info)
 
         line_height = self.font.get_linesize()


### PR DESCRIPTION
## Summary
- add world scale constants and default war map size
- enlarge example war configuration to 10km map with distant capitals
- update viewer scale bar and implement zoom/pan controls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1fca386048330b8d21629ac838723