### PR TITLE
Add A* pathfinding and combat blocking

### DIFF
--- a/docs/checklists/war_simulation_upgrade_checklist.md
+++ b/docs/checklists/war_simulation_upgrade_checklist.md
@@ -87,12 +87,12 @@
 
 ## 4) Combat Blocking & Pathfinding
 
-- [ ] **Add** `systems/pathfinding.py` (A* on grid using `TerrainNode.get_neighbors`, speed modifiers as costs).
-- [ ] **MovementSystem**:
-  - [ ] When a unit enters `fighting` state, mark its tile **temporarily blocked** to others (except same stack/formation). 
-  - [ ] If `avoid_obstacles=True`, consult `PathfindingSystem` for detours when the next step is blocked.
-- [ ] **CombatSystem**:
-  - [ ] Already engages when two enemy units share a tile. Ensure units in `fighting` don’t “slide through” (freeze movement until resolved).
+- [x] **Add** `systems/pathfinding.py` (A* on grid using `TerrainNode.get_neighbors`, speed modifiers as costs).
+- [x] **MovementSystem**:
+  - [x] When a unit enters `fighting` state, mark its tile **temporarily blocked** to others (except same stack/formation).
+  - [x] If `avoid_obstacles=True`, consult `PathfindingSystem` for detours when the next step is blocked.
+- [x] **CombatSystem**:
+  - [x] Already engages when two enemy units share a tile. Ensure units in `fighting` don’t “slide through” (freeze movement until resolved).
 
 ---
 

--- a/systems/pathfinding.py
+++ b/systems/pathfinding.py
@@ -1,0 +1,95 @@
+"""A* pathfinding system leveraging terrain speed modifiers."""
+from __future__ import annotations
+
+import heapq
+from typing import Dict, List, Optional, Tuple, Set
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.terrain import TerrainNode
+
+
+class PathfindingSystem(SystemNode):
+    """Compute paths on the terrain grid using the A* algorithm.
+
+    Parameters
+    ----------
+    terrain:
+        Reference to the :class:`TerrainNode` containing map information.
+        If a string is supplied the node with this id is looked up on first
+        update.
+    """
+
+    def __init__(self, terrain: TerrainNode | str | None = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._terrain_ref = terrain
+        self.terrain: TerrainNode | None = terrain if isinstance(terrain, TerrainNode) else None
+
+    # ------------------------------------------------------------------
+    def _resolve_terrain(self) -> None:
+        if self.terrain is not None:
+            return
+        name = self._terrain_ref if isinstance(self._terrain_ref, str) else None
+        root = self.parent
+        if root is None:
+            return
+        self.terrain = self._find_terrain(root, name)
+
+    def _find_terrain(self, node: SimNode, name: str | None) -> TerrainNode | None:
+        if isinstance(node, TerrainNode) and (name is None or node.name == name):
+            return node
+        for child in node.children:
+            found = self._find_terrain(child, name)
+            if found is not None:
+                return found
+        return None
+
+    # ------------------------------------------------------------------
+    def _heuristic(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:
+        return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+    # ------------------------------------------------------------------
+    def find_path(
+        self,
+        start: Tuple[int, int],
+        goal: Tuple[int, int],
+        blocked: Optional[Set[Tuple[int, int]]] = None,
+    ) -> List[Tuple[int, int]]:
+        """Return a list of coordinates from ``start`` to ``goal``.
+
+        If no path is found an empty list is returned. ``blocked`` may contain
+        additional temporarily impassable coordinates such as ongoing combats.
+        """
+
+        self._resolve_terrain()
+        if self.terrain is None:
+            return []
+        blocked = blocked or set()
+        open_set: List[Tuple[float, Tuple[int, int]]] = []
+        heapq.heappush(open_set, (0.0, start))
+        came_from: Dict[Tuple[int, int], Tuple[int, int]] = {}
+        g_score: Dict[Tuple[int, int], float] = {start: 0.0}
+        while open_set:
+            _, current = heapq.heappop(open_set)
+            if current == goal:
+                path = [current]
+                while current in came_from:
+                    current = came_from[current]
+                    path.append(current)
+                path.reverse()
+                return path
+            for neighbor in self.terrain.get_neighbors(*current):
+                if neighbor in blocked or self.terrain.is_obstacle(*neighbor):
+                    continue
+                cost = 1.0 / self.terrain.get_speed_modifier(*neighbor)
+                tentative = g_score[current] + cost
+                if tentative >= g_score.get(neighbor, float("inf")):
+                    continue
+                came_from[neighbor] = current
+                g_score[neighbor] = tentative
+                f_score = tentative + self._heuristic(neighbor, goal)
+                heapq.heappush(open_set, (f_score, neighbor))
+        return []
+
+
+register_node_type("PathfindingSystem", PathfindingSystem)

--- a/tests/test_movement_system.py
+++ b/tests/test_movement_system.py
@@ -3,6 +3,7 @@ from nodes.terrain import TerrainNode
 from nodes.unit import UnitNode
 from nodes.transform import TransformNode
 from systems.movement import MovementSystem
+from systems.pathfinding import PathfindingSystem
 
 
 def test_movement_considers_terrain_and_morale():
@@ -30,3 +31,22 @@ def test_map_obstacle_blocks_movement():
     world.update(1.0)
     transform = next(c for c in unit.children if isinstance(c, TransformNode))
     assert transform.position[0] == 0.0
+
+
+def test_fighting_unit_blocks_and_pathfinder_detours():
+    world = WorldNode()
+    terrain = TerrainNode(tiles=[["plain"] * 3 for _ in range(3)])
+    pathfinder = PathfindingSystem(parent=world, terrain=terrain)
+    MovementSystem(parent=world, terrain=terrain, avoid_obstacles=True, pathfinder=pathfinder)
+    moving = UnitNode(parent=world, speed=1.0, morale=100, target=[2, 0])
+    TransformNode(parent=moving, position=[0.0, 0.0])
+    blocker = UnitNode(parent=world, state="fighting")
+    TransformNode(parent=blocker, position=[1.0, 0.0])
+
+    # first update computes detour path without moving
+    world.update(1.0)
+    # second update follows the path around the fighting unit
+    world.update(1.0)
+    transform = next(c for c in moving.children if isinstance(c, TransformNode))
+    # The unit should move north to avoid the fighting tile at (1,0)
+    assert transform.position == [0.0, 1.0]

--- a/tests/test_pathfinding_system.py
+++ b/tests/test_pathfinding_system.py
@@ -1,0 +1,21 @@
+from nodes.terrain import TerrainNode
+from systems.pathfinding import PathfindingSystem
+
+
+def test_pathfinder_avoids_slow_tiles():
+    tiles = [
+        ["plain", "swamp", "plain"],
+        ["plain", "plain", "plain"],
+        ["plain", "plain", "plain"],
+    ]
+    terrain = TerrainNode(tiles=tiles, speed_modifiers={"plain": 1.0, "swamp": 0.1})
+    pf = PathfindingSystem(terrain=terrain)
+    path = pf.find_path((0, 0), (2, 0))
+    assert (1, 0) not in path
+
+
+def test_pathfinder_respects_blocked_tiles():
+    terrain = TerrainNode(tiles=[["plain"] * 3 for _ in range(3)])
+    pf = PathfindingSystem(terrain=terrain)
+    path = pf.find_path((0, 0), (2, 0), blocked={(1, 0)})
+    assert (1, 0) not in path


### PR DESCRIPTION
## Summary
- add `PathfindingSystem` implementing grid-based A* using terrain speed modifiers
- teach `MovementSystem` to block fighting tiles and consult pathfinder for detours
- document completed combat blocking and pathfinding tasks in the war simulation checklist

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a205be31ec83308c22e626fce7cfd0