### PR TITLE
Add terrain resolution cap and cached buffer to viewer

### DIFF
--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -254,6 +254,7 @@
 | scale | float | 5.0 |  Scale applied to positions stored in :class:`TransformNode`s. |
 | panel_width | int | 320 |  Width of the information panel appended to the right of the view. |
 | font_size | int | 14 |  Font size used to render the panel text. |
+| max_terrain_resolution | int | 2000 |  Maximum width or height of the cached terrain surface in pixels. |
 | kwargs | _empty |  |  |
 
 ### SchedulerSystem


### PR DESCRIPTION
## Summary
- add `max_terrain_resolution` option to `PygameViewerSystem`
- precompute averaged terrain surface and blit cached buffer
- document new parameter in parameter inventory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a21ac508b08330be554879a6edde69