### PR TITLE
Centralize war simulation parameters

### DIFF
--- a/docs/checklists/run_war_enhancement_roadmap.md
+++ b/docs/checklists/run_war_enhancement_roadmap.md
@@ -19,10 +19,10 @@ architecture as described in `docs/specs/project_spec.md`.
 - [x] Write tests for basic exploration logic.
 
 ## 3. Central Simulation Parameters
-- [ ] Introduce a dedicated settings file with a `parameters` section collecting
+- [x] Introduce a dedicated settings file with a `parameters` section collecting
   key simulation values (e.g., unit sizes, vision radius, AI flags).
-- [ ] Load these parameters in `run_war.py` and expose them to systems via `SimParams`.
-- [ ] Document parameter meanings in the file and in `docs/parameter_inventory.md`.
+- [x] Load these parameters in `run_war.py` and expose them to systems via `SimParams`.
+- [x] Document parameter meanings in the file and in `docs/parameter_inventory.md`.
 
 ## 4. Menu Buttons for Live Parameters
 - [ ] In the viewer menu, add +/- buttons next to parameters that already have

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -1,5 +1,18 @@
 # Parameter inventory
 
+## Simulation Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| dispersion | float | 200.0 | Maximum radius around a nation's capital used when spawning armies. |
+| unit_size | int | 5 | Base number of soldiers per unit before rounding to multiples of `soldiers_per_dot`. |
+| soldiers_per_dot | int | 5 | Number of soldiers represented by a single viewer dot. |
+| bodyguard_size | int | 5 | Number of soldiers in each bodyguard unit. |
+| vision_radius_m | float | 100.0 | Vision radius in meters for units, used by the visibility system. |
+| visibility | bool | True | Enable fog of war processing. |
+| command_delay | float | 0.0 | Base delay in seconds before commands reach units. |
+| movement_blocking | bool | True | Whether units block each other's movement. |
+
 ## Nodes
 
 ### AIBehaviorNode

--- a/example/war_settings.json
+++ b/example/war_settings.json
@@ -1,0 +1,22 @@
+{
+  "parameters": {
+    "dispersion": 200.0,
+    "unit_size": 5,
+    "soldiers_per_dot": 5,
+    "bodyguard_size": 5,
+    "vision_radius_m": 100.0,
+    "visibility": true,
+    "command_delay": 0.0,
+    "movement_blocking": true
+  },
+  "descriptions": {
+    "dispersion": "Max distance from the nation's capital when spawning units (meters)",
+    "unit_size": "Base number of soldiers per unit before rounding to soldiers_per_dot",
+    "soldiers_per_dot": "Number of soldiers represented by a single dot in the viewer",
+    "bodyguard_size": "Number of soldiers in each bodyguard unit protecting the general",
+    "vision_radius_m": "Unit vision radius in meters for fog of war calculations",
+    "visibility": "Enable fog of war via the VisibilitySystem",
+    "command_delay": "Base seconds commands are delayed before reaching units",
+    "movement_blocking": "Whether units block each other during movement"
+  }
+}

--- a/tests/test_sim_params.py
+++ b/tests/test_sim_params.py
@@ -1,0 +1,51 @@
+import os
+import json
+import random
+
+os.environ["RUN_WAR_IMPORT_ONLY"] = "1"
+
+from nodes.world import WorldNode
+from nodes.nation import NationNode
+from nodes.general import GeneralNode
+from nodes.transform import TransformNode
+from nodes.army import ArmyNode
+from nodes.unit import UnitNode
+
+from run_war import load_sim_params, _spawn_armies, sim_params
+
+
+def test_load_sim_params(tmp_path):
+    data = {"parameters": {"unit_size": 7, "vision_radius_m": 150.0}}
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(data))
+
+    params = load_sim_params(str(path))
+    assert params["unit_size"] == 7
+    assert params["vision_radius_m"] == 150.0
+    # ensure defaults are preserved
+    assert params["dispersion"] == 200.0
+
+
+def test_spawn_armies_respects_sim_params():
+    random.seed(0)
+    world = WorldNode(width=3, height=3)
+    north = NationNode(parent=world, name="north", capital_position=[0, 0], morale=100)
+    g_north = GeneralNode(parent=north, style="balanced")
+    TransformNode(parent=g_north, position=[0, 0])
+    south = NationNode(parent=world, name="south", capital_position=[2, 2], morale=100)
+    g_south = GeneralNode(parent=south, style="balanced")
+    TransformNode(parent=g_south, position=[2, 2])
+
+    old_params = dict(sim_params)
+    try:
+        sim_params["unit_size"] = 20
+        sim_params["vision_radius_m"] = 50.0
+        _spawn_armies(world, 0, sim_params["soldiers_per_dot"], sim_params["bodyguard_size"], None)
+
+        army = next(c for c in g_north.children if isinstance(c, ArmyNode))
+        unit = next(c for c in army.get_officers()[0].children if isinstance(c, UnitNode))
+        assert unit.size == 20
+        assert unit.vision_radius_m == 50.0
+    finally:
+        sim_params.clear()
+        sim_params.update(old_params)


### PR DESCRIPTION
## Summary
- centralize adjustable war settings into `war_settings.json`
- load parameters in `run_war.py` via `load_sim_params` and propagate to armies and systems
- document new parameters in `docs/parameter_inventory.md` and update roadmap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34964956883308c82c2b8fbdf108d