### PR TITLE
Add viewer buttons for live war parameters

### DIFF
--- a/docs/checklists/run_war_enhancement_roadmap.md
+++ b/docs/checklists/run_war_enhancement_roadmap.md
@@ -25,10 +25,10 @@ architecture as described in `docs/specs/project_spec.md`.
 - [x] Document parameter meanings in the file and in `docs/parameter_inventory.md`.
 
 ## 4. Menu Buttons for Live Parameters
-- [ ] In the viewer menu, add +/- buttons next to parameters that already have
+- [x] In the viewer menu, add +/- buttons next to parameters that already have
   keyboard bindings.
-- [ ] Buttons trigger the same handlers as keyboard shortcuts for consistency.
-- [ ] Update on-screen help panel to show both keyboard and button controls.
+- [x] Buttons trigger the same handlers as keyboard shortcuts for consistency.
+- [x] Update on-screen help panel to show both keyboard and button controls.
 
 ## 5. Terrain Generation (Checklist §2)
 

--- a/tests/test_pygame_viewer.py
+++ b/tests/test_pygame_viewer.py
@@ -1,5 +1,4 @@
 import os
-
 import pytest
 
 from nodes.world import WorldNode
@@ -60,4 +59,36 @@ def test_viewer_draws_overlay():
     assert viewer.screen.get_at((5, 5))[:3] == (80, 160, 80)
     assert viewer.screen.get_at((30, 30))[:3] == (200, 50, 50)
     assert viewer.screen.get_at((20, 30))[:3] == (255, 255, 0)
+    pygame.quit()
+
+
+def test_menu_buttons_trigger_callbacks():
+    pygame = pytest.importorskip("pygame")
+    from systems.pygame_viewer import PygameViewerSystem
+
+    os.environ["SDL_VIDEODRIVER"] = "dummy"
+    world = WorldNode(name="world")
+    viewer = PygameViewerSystem(parent=world, width=100, height=80, panel_width=80)
+
+    calls = {"minus": 0, "plus": 0}
+
+    def dec():
+        calls["minus"] += 1
+
+    def inc():
+        calls["plus"] += 1
+
+    viewer.set_menu_items([{ "label": "Val", "minus": dec, "plus": inc }])
+    world.update(0)
+
+    minus_rect, plus_rect = viewer._menu_button_rects[0][0], viewer._menu_button_rects[1][0]
+    viewer.process_events([
+        pygame.event.Event(pygame.MOUSEBUTTONDOWN, {"pos": minus_rect.center, "button": 1})
+    ])
+    viewer.process_events([
+        pygame.event.Event(pygame.MOUSEBUTTONDOWN, {"pos": plus_rect.center, "button": 1})
+    ])
+
+    assert calls["minus"] == 1
+    assert calls["plus"] == 1
     pygame.quit()


### PR DESCRIPTION
## Summary
- add interactive menu items with plus/minus buttons in pygame viewer
- expose dispersion, command delay and forest coverage via menu buttons in run_war
- cover new UI buttons with a dedicated test and update roadmap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34b4c95f8833082e7addfc71165bd