### PR TITLE
Tune viewer defaults for faster startup

### DIFF
--- a/docs/checklists/refactor_checklist_war.md
+++ b/docs/checklists/refactor_checklist_war.md
@@ -46,15 +46,15 @@ Cette checklist décrit les actions à réaliser pour supprimer la simulation de
 - [x] Profiler et optimiser `systems/movement.py`, `systems/pathfinding.py`, `systems/visibility.py` :
   - Utiliser des structures de données plus efficaces si nécessaire (numpy, graphes optimisés).
   - Réduire la fréquence des calculs et logs.
-- [ ] Vérifier `pygame_viewer.py` :
+- [x] Vérifier `pygame_viewer.py` :
   - Paramétrer correctement `max_terrain_resolution` et les options de rendu pour accélérer le démarrage.
 
 ---
 
 ## 4. Tests et documentation
 
-- [ ] Supprimer les tests liés à la ferme (farm, barn, etc.).
-- [ ] Vérifier que les tests restants couvrent les nœuds et systèmes militaires.
+- [x] Supprimer les tests liés à la ferme (farm, barn, etc.).
+- [x] Vérifier que les tests restants couvrent les nœuds et systèmes militaires.
 - [ ] Ajouter de nouveaux tests unitaires pour :
   - ArmyNode, UnitNode, OfficerNode.
   - Systèmes combat, moral, pathfinding, victoire.

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -81,7 +81,8 @@ class PygameViewerSystem(SystemNode):
         panel_width: int = config.PANEL_WIDTH,
         font_size: int = config.FONT_SIZE,
         draw_capital: bool = False,
-        max_terrain_resolution: int = 2000,
+        # Cache terrain at a modest resolution to avoid long pre-render times
+        max_terrain_resolution: int = 1024,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -100,11 +101,11 @@ class PygameViewerSystem(SystemNode):
         self.offset_y = 0.0
         self.selected: Optional[SimNode] = None
         self.unit_radius = UNIT_RADIUS
-        # number of soldiers represented by a single dot
-        self.soldiers_per_dot = 1
+        # number of soldiers represented by a single dot – coarser by default for speed
+        self.soldiers_per_dot = 10
         self.draw_capital = draw_capital
-        # Toggle display options
-        self.show_role_rings = True
+        # Toggle display options (disabled overlays yield a faster startup)
+        self.show_role_rings = False
         self.show_intel_overlay = False
         # Extra informational lines injected by external code (e.g. pause menu)
         self.extra_info: List[str] = []


### PR DESCRIPTION
## Summary
- Reduce default Pygame viewer terrain cache resolution and disable overlays for quicker launch
- Mark refactor checklist items for viewer tuning and farm test cleanup as complete

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3628cfc808330a9aa0043a316ef8f