### PR TITLE
Expand war simulation tests and docs

### DIFF
--- a/docs/checklists/refactor_checklist_war.md
+++ b/docs/checklists/refactor_checklist_war.md
@@ -55,11 +55,11 @@ Cette checklist décrit les actions à réaliser pour supprimer la simulation de
 
 - [x] Supprimer les tests liés à la ferme (farm, barn, etc.).
 - [x] Vérifier que les tests restants couvrent les nœuds et systèmes militaires.
-- [ ] Ajouter de nouveaux tests unitaires pour :
+- [x] Ajouter de nouveaux tests unitaires pour :
   - ArmyNode, UnitNode, OfficerNode.
   - Systèmes combat, moral, pathfinding, victoire.
   - Chargement de presets et cohérence des paramètres.
-- [ ] Mettre à jour la documentation dans `docs/` pour :
+- [x] Mettre à jour la documentation dans `docs/` pour :
   - Fournir un guide clair sur la simulation de guerre.
   - Documenter la nouvelle architecture modulaire.
   - Lister les paramètres disponibles (remplacer `parameter_inventory.md`).

--- a/docs/guides/war_simulation.md
+++ b/docs/guides/war_simulation.md
@@ -1,0 +1,27 @@
+# War Simulation Guide
+
+This guide explains how to run and experiment with the war simulation.
+
+## Running the simulation
+
+```
+python run_war.py [config.json] [settings.json]
+```
+
+- **config.json**: world layout and initial entities.
+- **settings.json**: simulation parameters such as unit size or terrain presets.
+
+The default files in the `example/` directory are used when no arguments are
+supplied.
+
+## Controls
+
+- `Space` – advance the simulation by one tick.
+- `P` – toggle continuous play.
+- `Q` – quit the viewer.
+
+## Extending
+
+Nodes and systems are loaded through the plugin mechanism. New units or gameplay
+systems can be added by creating new modules and registering them with
+`core.plugins.register_node_type` or `register_system_type`.

--- a/docs/modular_architecture.md
+++ b/docs/modular_architecture.md
@@ -1,0 +1,12 @@
+# Modular Architecture
+
+The simulation engine is built from loosely coupled nodes and systems.
+
+- **Nodes** represent entities such as nations, armies or terrain. Each node
+  inherits from `core.simnode.SimNode` and can emit or listen to events.
+- **Systems** encapsulate global behaviours like combat resolution or pathfinding.
+- **Plugins**: new nodes and systems are registered via the plugin mechanism,
+  allowing features to be added without modifying core modules.
+
+The war simulation packages these pieces under `simulation/war/` with separate
+subpackages for nodes, systems, terrain generation and the viewer loop.

--- a/docs/parameter_inventory.md
+++ b/docs/parameter_inventory.md
@@ -1,0 +1,12 @@
+# Parameter Inventory
+
+List of configurable simulation parameters used by the war module.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `dispersion` | Initial dispersion radius when spawning units around a leader. | 200.0 |
+| `unit_size` | Number of soldiers per combat unit. | 5 |
+| `soldiers_per_dot` | Scaling factor for visual representation. | 5 |
+| `bodyguard_size` | Number of soldiers in a general's bodyguard unit. | 5 |
+| `vision_radius_m` | Vision range in meters for detection systems. | 100.0 |
+| `movement_blocking` | Whether terrain obstacles block movement. | True |

--- a/tests/test_army_node.py
+++ b/tests/test_army_node.py
@@ -1,5 +1,7 @@
 from core.simnode import SimNode
 from nodes.army import ArmyNode
+from nodes.officer import OfficerNode
+from nodes.unit import UnitNode
 
 
 def test_goal_change_and_unit_listing():
@@ -12,9 +14,6 @@ def test_goal_change_and_unit_listing():
     assert army.goal == "advance"
     assert events[0]["previous"] == "defend"
     assert events[0]["goal"] == "advance"
-
-    class UnitNode(SimNode):
-        pass
 
     unit = UnitNode(name="unit")
     army.add_child(unit)
@@ -38,3 +37,14 @@ def test_unit_events_update_size_and_emit_report():
 
     assert army.size == 0
     assert reports[0]["type"] == "unit_routed"
+
+
+def test_get_officers_lists_only_officers_and_units():
+    army = ArmyNode(goal="advance", size=0)
+    officer = OfficerNode(name="officer")
+    unit = UnitNode(name="unit")
+    army.add_child(officer)
+    army.add_child(unit)
+
+    assert army.get_officers() == [officer]
+    assert army.get_units() == [unit]

--- a/tests/test_combat_system.py
+++ b/tests/test_combat_system.py
@@ -31,3 +31,23 @@ def test_combat_routes_losing_unit_and_reduces_morale():
     assert n_unit.state == "fleeing"
     assert s_unit.state == "fighting"
     assert north.morale < 100
+
+
+def test_combat_system_resolves_terrain_by_name():
+    world = WorldNode()
+    terrain = TerrainNode(parent=world, name="map", tiles=[["plain"]])
+    cs = CombatSystem(parent=world, terrain="map")
+
+    north = NationNode(parent=world, morale=100, capital_position=[0, 0])
+    south = NationNode(parent=world, morale=100, capital_position=[0, 0])
+    n_army = ArmyNode(parent=north, goal="defend", size=1)
+    s_army = ArmyNode(parent=south, goal="advance", size=1)
+    n_unit = UnitNode(parent=n_army, size=10)
+    s_unit = UnitNode(parent=s_army, size=5)
+    TransformNode(parent=n_unit, position=[0, 0])
+    TransformNode(parent=s_unit, position=[0, 0])
+
+    world.update(1.0)
+
+    assert cs.terrain is terrain
+    assert s_unit.state == "fleeing"

--- a/tests/test_moral_system.py
+++ b/tests/test_moral_system.py
@@ -17,3 +17,18 @@ def test_nation_collapses_when_morale_depleted():
     nation.change_morale(-5)
     world.update(1.0)
     assert collapsed and collapsed[0]["morale"] <= 0
+
+
+def test_collapse_emitted_only_once():
+    world = WorldNode()
+    MoralSystem(parent=world)
+    nation = NationNode(parent=world, morale=2, capital_position=[0, 0])
+    collapsed: list[dict] = []
+    nation.on_event("nation_collapsed", lambda _o, _e, p: collapsed.append(p))
+
+    nation.change_morale(-2)
+    world.update(1.0)
+    nation.change_morale(-1)
+    world.update(1.0)
+
+    assert len(collapsed) == 1

--- a/tests/test_officer_node.py
+++ b/tests/test_officer_node.py
@@ -1,0 +1,21 @@
+from core.simnode import SimNode
+from nodes.officer import OfficerNode
+from nodes.unit import UnitNode
+
+
+def test_order_forwarding_and_unit_listing():
+    root = SimNode("root")
+    officer = OfficerNode(parent=root)
+    unit = UnitNode(parent=officer)
+    acks: list[dict] = []
+    issued: list[dict] = []
+    root.on_event("order_ack", lambda _o, _e, p: acks.append(p))
+    root.on_event("order_issued", lambda _o, _e, p: issued.append(p))
+
+    order = {"command": "advance", "recipient": unit.name}
+    officer.emit("order_received", order)
+
+    assert acks and acks[0]["order"] == order
+    assert issued and issued[0]["recipient_group"] == "units"
+    assert issued[0]["issuer_id"] == id(officer)
+    assert officer.get_units() == [unit]

--- a/tests/test_pathfinding_system.py
+++ b/tests/test_pathfinding_system.py
@@ -1,5 +1,6 @@
 from nodes.terrain import TerrainNode
 from systems.pathfinding import PathfindingSystem
+from nodes.world import WorldNode
 
 
 def test_pathfinder_avoids_slow_tiles():
@@ -32,3 +33,12 @@ def test_pathfinder_cost_monotonic() -> None:
         cumulative += 1.0 / terrain.get_speed_modifier(x, y)
         costs.append(cumulative)
     assert costs == sorted(costs)
+
+
+def test_resolves_terrain_by_name():
+    world = WorldNode()
+    terrain = TerrainNode(parent=world, name="map", tiles=[["plain", "plain"]])
+    pf = PathfindingSystem(parent=world, terrain="map")
+    path = pf.find_path((0, 0), (1, 0))
+    assert pf.terrain is terrain
+    assert path == [(0, 0), (1, 0)]

--- a/tests/test_unit_node.py
+++ b/tests/test_unit_node.py
@@ -34,3 +34,23 @@ def test_unit_retreats_when_morale_low():
 
     assert unit.state == "fleeing"
     assert unit.target == [0, 0]
+
+
+def test_order_acknowledgement_and_completion():
+    root = SimNode("root")
+    unit = UnitNode(parent=root)
+    acks: list[dict] = []
+    completed: list[dict] = []
+    root.on_event("order_ack", lambda _o, _e, p: acks.append(p))
+    root.on_event("order_complete", lambda _o, _e, p: completed.append(p))
+
+    order = {"action": "move", "priority": 1, "time_issued": 1}
+    root.emit("order_received", order, direction="down")
+
+    assert unit.current_order == order
+    assert acks and acks[0]["order"] == order
+
+    unit.complete_order()
+
+    assert unit.current_order is None
+    assert completed and completed[0]["order"] == order

--- a/tests/test_victory_system.py
+++ b/tests/test_victory_system.py
@@ -51,3 +51,20 @@ def test_nation_defeated_on_moral_collapse():
     nation.change_morale(-1)
     world.update(1.0)
     assert defeated and defeated[0]["reason"] == "moral_collapse"
+
+
+def test_capital_capture_emitted_only_once():
+    world = WorldNode()
+    VictorySystem(parent=world, capture_unit_threshold=1)
+    attacker = NationNode(parent=world, morale=100, capital_position=[5, 0])
+    defender = NationNode(parent=world, morale=100, capital_position=[0, 0])
+    unit1 = UnitNode(parent=attacker)
+    TransformNode(parent=unit1, position=[0, 0])
+    events: list[dict] = []
+    defender.on_event("capital_captured", lambda _o, _e, p: events.append(p))
+    world.update(1.0)
+    assert len(events) == 1
+    unit2 = UnitNode(parent=attacker)
+    TransformNode(parent=unit2, position=[0, 0])
+    world.update(1.0)
+    assert len(events) == 1

--- a/tests/test_war_preset_loading.py
+++ b/tests/test_war_preset_loading.py
@@ -1,0 +1,16 @@
+import json
+from simulation.war import war_loader
+from simulation.war.presets import DEFAULT_SIM_PARAMS
+
+
+def test_load_sim_params_applies_overrides_and_defaults(tmp_path):
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"parameters": {"unit_size": 42}}))
+    params = war_loader.load_sim_params(str(path))
+    assert params["unit_size"] == 42
+    assert params["dispersion"] == DEFAULT_SIM_PARAMS["dispersion"]
+
+
+def test_load_sim_params_missing_file(tmp_path):
+    params = war_loader.load_sim_params(str(tmp_path / "missing.json"))
+    assert params == DEFAULT_SIM_PARAMS


### PR DESCRIPTION
## Summary
- Add unit tests for ArmyNode, UnitNode, OfficerNode and war systems
- Document war simulation usage, modular architecture and parameters
- Mark checklist items for tests and documentation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3636d6a3083308a879851d9d7232a