### PR TITLE
Include logger and time systems in war plugin loader

### DIFF
--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -54,6 +54,8 @@ def load_plugins_for_war() -> None:
             "systems.moral",
             "systems.pathfinding",
             "systems.victory",
+            "systems.time",
+            "systems.logger",
         ]
     )
 


### PR DESCRIPTION
## Summary
- ensure war loader registers time and logging systems

## Testing
- `pytest`
- `timeout 5s python run_war.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3572ea60c8330a02048c164fbd8ce