### PR TITLE
Add BuildingNode and ResourceNode with example configuration

### DIFF
--- a/example/farm_warehouse.json
+++ b/example/farm_warehouse.json
@@ -1,0 +1,32 @@
+{
+  "world": {
+    "type": "WorldNode",
+    "config": {"width": 100, "height": 100, "seed": 1},
+    "children": [
+      {
+        "type": "BuildingNode",
+        "id": "farm",
+        "config": {"type": "farm", "capacity": 5, "hit_points": 100},
+        "children": [
+          {
+            "type": "ResourceNode",
+            "id": "grain_stock",
+            "config": {"kind": "grain", "quantity": 20, "max_quantity": 100}
+          }
+        ]
+      },
+      {
+        "type": "BuildingNode",
+        "id": "warehouse",
+        "config": {"type": "warehouse", "capacity": 200, "hit_points": 250},
+        "children": [
+          {
+            "type": "ResourceNode",
+            "id": "wood_stock",
+            "config": {"kind": "wood", "quantity": 50, "max_quantity": 500}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/global_spec.md
+++ b/global_spec.md
@@ -157,6 +157,11 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 
 ---
 
+## Exemples
+Un fichier de configuration minimal `example/farm_warehouse.json` illustre une ferme et un entrepôt utilisant `BuildingNode` et `ResourceNode` avec des stocks initiaux.
+
+---
+
 ## Notes de développement
 - Le système doit minimiser les calculs inutiles : les ouvriers ne font pas de vérification à chaque tick.
 - Tous les comportements IA restent simples mais extensibles.

--- a/nodes/building.py
+++ b/nodes/building.py
@@ -1,0 +1,28 @@
+"""Building node representing structures in the simulation."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class BuildingNode(SimNode):
+    """Represent a building such as a farm or warehouse.
+
+    Parameters
+    ----------
+    type:
+        Type of building (e.g., ``"farm"``, ``"warehouse"``).
+    capacity:
+        Maximum capacity of units or resources handled by the building.
+    hit_points:
+        Structural durability used in combat interactions.
+    """
+
+    def __init__(self, type: str, capacity: int = 0, hit_points: int = 100, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.type = type
+        self.capacity = capacity
+        self.hit_points = hit_points
+
+
+register_node_type("BuildingNode", BuildingNode)

--- a/nodes/resource.py
+++ b/nodes/resource.py
@@ -1,0 +1,49 @@
+"""Resource node representing a stockpile of materials."""
+from __future__ import annotations
+
+from core.simnode import SimNode
+from core.plugins import register_node_type
+
+
+class ResourceNode(SimNode):
+    """Track the quantity of a single resource type.
+
+    Parameters
+    ----------
+    kind:
+        Type of resource stored (e.g., ``"wood"``, ``"grain"``).
+    quantity:
+        Current amount of the resource.
+    max_quantity:
+        Maximum capacity for the resource.
+    """
+
+    def __init__(self, kind: str, quantity: int = 0, max_quantity: int = 0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.kind = kind
+        self.quantity = quantity
+        self.max_quantity = max_quantity
+
+    # ------------------------------------------------------------------
+    def add(self, amount: int) -> int:
+        """Add ``amount`` to the stockpile and return the added amount."""
+
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        space = self.max_quantity - self.quantity
+        added = min(space, amount) if self.max_quantity else amount
+        self.quantity += added
+        return added
+
+    # ------------------------------------------------------------------
+    def remove(self, amount: int) -> int:
+        """Remove up to ``amount`` from the stockpile and return removed."""
+
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        removed = min(self.quantity, amount)
+        self.quantity -= removed
+        return removed
+
+
+register_node_type("ResourceNode", ResourceNode)

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -49,6 +49,8 @@ def load_plugins_for_war() -> None:
             "nodes.strategist",
             "nodes.officer",
             "nodes.bodyguard",
+            "nodes.building",
+            "nodes.resource",
             "systems.movement",
             "systems.combat",
             "systems.moral",


### PR DESCRIPTION
## Summary
- implement BuildingNode and ResourceNode classes
- register new node modules in war loader
- add farm_warehouse example and update global spec

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a36e5eae9883308f9c43f2e2debbd8