### PR TITLE
Add EconomySystem for resource management

### DIFF
--- a/global_spec.md
+++ b/global_spec.md
@@ -102,7 +102,7 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 - Gère la **production**, la **consommation** et les **transferts** de ressources.
 - Méthodes principales :
   - `produce(node, kind, amount)`
-  - `transfer(src, dst, kind, amount)`
+  - `transfer(src, dst, kind, amount)` (`dst` peut être `None` pour une consommation directe)
 - Émet des événements `resource_produced` et `resource_consumed`.
 - Lève une erreur si le stock est insuffisant.
 

--- a/systems/economy.py
+++ b/systems/economy.py
@@ -1,0 +1,58 @@
+"""System handling resource production, consumption and transfers."""
+from __future__ import annotations
+
+from core.simnode import SystemNode
+from core.plugins import register_node_type
+from nodes.resource import ResourceNode
+
+
+class EconomySystem(SystemNode):
+    """Manage stockpiles and resource exchanges."""
+
+    # ------------------------------------------------------------------
+    def produce(self, node: ResourceNode, kind: str, amount: int) -> int:
+        """Increase *node* by *amount* of *kind*.
+
+        Returns the actual amount produced and emits ``resource_produced``.
+        """
+
+        if node.kind != kind:
+            raise ValueError("resource kind mismatch")
+        added = node.add(amount)
+        if added:
+            node.emit("resource_produced", {"kind": kind, "amount": added})
+        return added
+
+    # ------------------------------------------------------------------
+    def transfer(
+        self,
+        src: ResourceNode,
+        dst: ResourceNode | None,
+        kind: str,
+        amount: int,
+    ) -> int:
+        """Move resources from *src* to *dst* or consume them if ``dst`` is ``None``.
+
+        Emits ``resource_consumed`` on the source and ``resource_produced`` on the
+        destination. Raises :class:`ValueError` when kinds mismatch, stock is
+        insufficient or the destination lacks capacity.
+        """
+
+        if src.kind != kind or (dst is not None and dst.kind != kind):
+            raise ValueError("resource kind mismatch")
+        if src.quantity < amount:
+            raise ValueError("insufficient stock")
+        src.remove(amount)
+        src.emit("resource_consumed", {"kind": kind, "amount": amount})
+        if dst is not None:
+            added = dst.add(amount)
+            if added < amount:
+                # roll back removal to maintain conservation
+                src.add(amount)
+                raise ValueError("destination lacks capacity")
+            dst.emit("resource_produced", {"kind": kind, "amount": added})
+        return amount
+
+
+register_node_type("EconomySystem", EconomySystem)
+

--- a/tests/test_economy.py
+++ b/tests/test_economy.py
@@ -1,0 +1,46 @@
+import pytest
+
+from nodes.world import WorldNode
+from nodes.resource import ResourceNode
+from systems.economy import EconomySystem
+
+
+def test_produce_emits_event_and_increases_stock():
+    world = WorldNode()
+    econ = EconomySystem(parent=world)
+    stock = ResourceNode(kind="wood", parent=world)
+    events: list[dict] = []
+    stock.on_event("resource_produced", lambda _o, _e, p: events.append(p))
+
+    econ.produce(stock, "wood", 5)
+
+    assert stock.quantity == 5
+    assert events and events[0]["amount"] == 5 and events[0]["kind"] == "wood"
+
+
+def test_transfer_moves_resources_and_emits_events():
+    world = WorldNode()
+    econ = EconomySystem(parent=world)
+    src = ResourceNode(kind="grain", quantity=10, parent=world)
+    dst = ResourceNode(kind="grain", parent=world)
+    consumed: list[dict] = []
+    produced: list[dict] = []
+    src.on_event("resource_consumed", lambda _o, _e, p: consumed.append(p))
+    dst.on_event("resource_produced", lambda _o, _e, p: produced.append(p))
+
+    econ.transfer(src, dst, "grain", 4)
+
+    assert src.quantity == 6
+    assert dst.quantity == 4
+    assert consumed and consumed[0]["amount"] == 4
+    assert produced and produced[0]["amount"] == 4
+
+
+def test_transfer_raises_on_insufficient_stock():
+    world = WorldNode()
+    econ = EconomySystem(parent=world)
+    src = ResourceNode(kind="stone", quantity=2, parent=world)
+    dst = ResourceNode(kind="stone", parent=world)
+
+    with pytest.raises(ValueError):
+        econ.transfer(src, dst, "stone", 5)


### PR DESCRIPTION
## Summary
- document: specify EconomySystem transfer can consume resources
- feat: implement EconomySystem with production and transfer operations
- test: cover resource production, transfer and insufficient stock errors

## Testing
- `pytest tests/test_economy.py`


------
https://chatgpt.com/codex/tasks/task_e_68a36f8d2494833093e9001d0993a3d5