### PR TITLE
Add WorkerNode with interval scheduling

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -1,0 +1,29 @@
+# Worker Nodes
+
+`WorkerNode` extends `UnitNode` to represent civilian workers capable of gathering resources or participating in building construction.
+
+## States
+- **idle** – no task assigned; the worker is removed from the scheduler.
+- **gathering** – actively collecting resources.
+- **building** – working on construction projects.
+
+## Scheduling
+Workers are updated by the `SchedulerSystem` at fixed intervals instead of every simulation tick. The interval is configured via the `update_interval` parameter (in seconds).
+
+```python
+from nodes.worker import WorkerNode
+from systems.scheduler import SchedulerSystem
+from nodes.world import WorldNode
+
+world = WorldNode(name="world")
+scheduler = SchedulerSystem(parent=world)
+worker = WorkerNode(parent=world, update_interval=2.0)
+
+# assign a gathering task
+worker.emit("task_assigned", {"task": "gathering"})
+
+# later, when finished
+worker.emit("task_complete")
+```
+
+When a task is assigned, the worker schedules itself with the scheduler. Upon task completion, it switches back to the `idle` state, emits `unit_idle` and unregisters from the scheduler.

--- a/global_spec.md
+++ b/global_spec.md
@@ -58,7 +58,8 @@ nodari/
 │   ├── pygame_viewer.py
 │   └── scheduler.py
 ├── docs/
-│   └── global_spec.md ← ce document
+│   ├── global_spec.md ← ce document
+│   └── workers.md
 └── tests/
     ├── test_ai.py
     ├── test_combat_building.py
@@ -92,6 +93,8 @@ Les nœuds représentent toutes les entités du monde (unités, bâtiments, stoc
 | `building`  | Participe à la construction d'un bâtiment.                       |
 
 Les transitions d'état sont déclenchées par des événements : `task_assigned`, `task_complete`, `unit_idle`.
+
+Voir `docs/workers.md` pour une documentation d'utilisation détaillée.
 
 ---
 

--- a/nodes/worker.py
+++ b/nodes/worker.py
@@ -1,0 +1,69 @@
+"""Worker unit node updated at intervals by the scheduler."""
+from __future__ import annotations
+
+from core.plugins import register_node_type
+from nodes.unit import UnitNode
+from systems.scheduler import SchedulerSystem
+
+
+class WorkerNode(UnitNode):
+    """Unit capable of gathering resources or constructing buildings.
+
+    Parameters
+    ----------
+    update_interval:
+        Seconds between updates when scheduled.
+    """
+
+    def __init__(self, update_interval: float = 1.0, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.update_interval = update_interval
+        # Idle workers are not updated automatically until scheduled.
+        self._manual_update = True
+        self.on_event("task_assigned", self._on_task_assigned)
+        self.on_event("task_complete", self._on_task_complete)
+
+    # ------------------------------------------------------------------
+    def _find_scheduler(self) -> SchedulerSystem | None:
+        """Return the :class:`SchedulerSystem` in the simulation tree."""
+
+        node = self
+        # ascend to root
+        while node.parent is not None:
+            node = node.parent
+        for child in node.children:
+            if isinstance(child, SchedulerSystem):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _on_task_assigned(self, _origin, _event, payload) -> None:
+        """Assign task and register with scheduler."""
+
+        task = payload.get("task") or payload.get("state")
+        if task in {"gather", "gathering"}:
+            self.state = "gathering"
+        elif task in {"build", "building"}:
+            self.state = "building"
+        else:
+            self.state = "idle"
+        scheduler = self._find_scheduler()
+        if scheduler is not None:
+            scheduler.unschedule(self)
+            if self.state != "idle":
+                scheduler.schedule(self, self.update_interval)
+
+    # ------------------------------------------------------------------
+    def _on_task_complete(self, _origin, _event, _payload) -> None:
+        """Return to idle state and unregister from scheduler."""
+
+        self.state = "idle"
+        scheduler = self._find_scheduler()
+        if scheduler is not None:
+            scheduler.unschedule(self)
+        # Remain excluded from automatic updates while idle.
+        self._manual_update = True
+        self.emit("unit_idle", {}, direction="up")
+
+
+register_node_type("WorkerNode", WorkerNode)

--- a/tests/test_worker_node.py
+++ b/tests/test_worker_node.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from nodes.worker import WorkerNode
+from nodes.world import WorldNode
+from systems.scheduler import SchedulerSystem
+
+
+class TestWorker(WorkerNode):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.count = 0
+
+    def update(self, dt: float) -> None:
+        self.count += 1
+        super().update(dt)
+
+
+def test_worker_scheduling_and_state():
+    world = WorldNode(name="world")
+    scheduler = SchedulerSystem(parent=world)
+    worker = TestWorker(parent=world, update_interval=2.0)
+
+    worker.emit("task_assigned", {"task": "gathering"})
+
+    assert worker.state == "gathering"
+    assert worker._manual_update is True
+    assert len(scheduler._tasks) == 1
+
+    for _ in range(5):
+        world.update(1.0)
+    assert worker.count == 2
+
+    worker.emit("task_complete", {})
+
+    assert worker.state == "idle"
+    assert worker._manual_update is True
+    assert len(scheduler._tasks) == 0
+
+    world.update(1.0)
+    assert worker.count == 2


### PR DESCRIPTION
## Summary
- implement WorkerNode with `idle`, `gathering`, and `building` states
- update workers through SchedulerSystem at fixed intervals and unschedule when idle
- document worker usage and reference in global spec

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a370a011ec833081d035933f77c04b