### PR TITLE
Add basic AI exploration and worker task finder

### DIFF
--- a/global_spec.md
+++ b/global_spec.md
@@ -94,6 +94,8 @@ Les nœuds représentent toutes les entités du monde (unités, bâtiments, stoc
 
 Les transitions d'état sont déclenchées par des événements : `task_assigned`, `task_complete`, `unit_idle`.
 
+La méthode `find_task()` sélectionne la ressource disponible la plus proche grâce au `PathfindingSystem` et assigne la cible en émettant `unit_move`.
+
 Voir `docs/workers.md` pour une documentation d'utilisation détaillée.
 
 ---
@@ -117,7 +119,7 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 - Réagit à `unit_idle` pour chercher une nouvelle tâche via `find_task()`.
 - Stratégies :
   - **Recherche de ressource** la plus proche en utilisant `systems.pathfinding`.
-  - **Exploration** de coordonnées inconnues en émettant `unit_move`.
+  - **Exploration** de coordonnées inconnues dans un rayon donné en émettant `unit_move`.
 
 ### `CombatSystem`
 - Permet d'attaquer des unités et des bâtiments (`attack_building`).

--- a/nodes/worker.py
+++ b/nodes/worker.py
@@ -2,8 +2,12 @@
 from __future__ import annotations
 
 from core.plugins import register_node_type
+from core.simnode import SimNode
 from nodes.unit import UnitNode
+from nodes.resource import ResourceNode
+from nodes.transform import TransformNode
 from systems.scheduler import SchedulerSystem
+from systems.pathfinding import PathfindingSystem
 
 
 class WorkerNode(UnitNode):
@@ -64,6 +68,81 @@ class WorkerNode(UnitNode):
         # Remain excluded from automatic updates while idle.
         self._manual_update = True
         self.emit("unit_idle", {}, direction="up")
+
+    # ------------------------------------------------------------------
+    def _find_pathfinder(self) -> PathfindingSystem | None:
+        """Return the :class:`PathfindingSystem` in the simulation tree."""
+
+        node = self
+        while node.parent is not None:
+            node = node.parent
+        for child in node.children:
+            if isinstance(child, PathfindingSystem):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _get_transform(self, node: SimNode) -> TransformNode | None:
+        if isinstance(node, TransformNode):
+            return node
+        for child in node.children:
+            if isinstance(child, TransformNode):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _iter_resources(self, node: SimNode):
+        for child in node.children:
+            if isinstance(child, ResourceNode):
+                yield child
+            yield from self._iter_resources(child)
+
+    # ------------------------------------------------------------------
+    def find_task(self) -> bool:
+        """Assign the worker to the nearest resource or zone.
+
+        The closest accessible :class:`ResourceNode` is selected using the
+        :class:`PathfindingSystem`. If a target is found the worker's ``target``
+        and ``state`` are updated and a ``unit_move`` event is emitted.
+
+        Returns ``True`` if a task was assigned.
+        """
+
+        pathfinder = self._find_pathfinder()
+        transform = self._get_transform(self)
+        if pathfinder is None or transform is None:
+            return False
+
+        start = (
+            int(round(transform.position[0])),
+            int(round(transform.position[1])),
+        )
+        root = self
+        while root.parent is not None:
+            root = root.parent
+
+        nearest = None
+        best_len = float("inf")
+        for res in self._iter_resources(root):
+            r_tr = self._get_transform(res)
+            if r_tr is None:
+                continue
+            goal = (
+                int(round(r_tr.position[0])),
+                int(round(r_tr.position[1])),
+            )
+            path = pathfinder.find_path(start, goal)
+            if path and len(path) < best_len:
+                best_len = len(path)
+                nearest = goal
+
+        if nearest is None:
+            return False
+
+        self.target = [nearest[0], nearest[1]]
+        self.state = "moving"
+        self.emit("unit_move", {"to": self.target}, direction="up")
+        return True
 
 
 register_node_type("WorkerNode", WorkerNode)

--- a/systems/ai.py
+++ b/systems/ai.py
@@ -1,0 +1,92 @@
+"""Simple AI system reacting to idle units."""
+from __future__ import annotations
+
+import random
+
+from core.simnode import SystemNode, SimNode
+from core.plugins import register_node_type
+from nodes.worker import WorkerNode
+from nodes.transform import TransformNode
+from nodes.nation import NationNode
+from systems.visibility import VisibilitySystem
+
+
+class AISystem(SystemNode):
+    """Assign tasks to idle workers and explore unknown territory."""
+
+    def __init__(self, exploration_radius: int = 5, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.exploration_radius = exploration_radius
+        self.on_event("unit_idle", self._on_unit_idle)
+
+    # ------------------------------------------------------------------
+    def _on_unit_idle(self, origin: SimNode, _event: str, _payload: dict) -> None:
+        if not isinstance(origin, WorkerNode):
+            return
+        if origin.find_task():
+            return
+        transform = self._get_transform(origin)
+        if transform is None:
+            return
+        x0 = int(round(transform.position[0]))
+        y0 = int(round(transform.position[1]))
+        radius = self.exploration_radius
+        explored = self._get_explored(origin)
+        for dx in range(-radius, radius + 1):
+            for dy in range(-radius, radius + 1):
+                if dx * dx + dy * dy > radius * radius:
+                    continue
+                pos = (x0 + dx, y0 + dy)
+                if pos in explored:
+                    continue
+                origin.target = [pos[0], pos[1]]
+                origin.state = "moving"
+                origin.emit("unit_move", {"to": origin.target}, direction="up")
+                return
+        # fallback random move if everything explored
+        dx = random.randint(-radius, radius)
+        dy = random.randint(-radius, radius)
+        origin.target = [x0 + dx, y0 + dy]
+        origin.state = "moving"
+        origin.emit("unit_move", {"to": origin.target}, direction="up")
+
+    # ------------------------------------------------------------------
+    def _get_transform(self, node: SimNode) -> TransformNode | None:
+        if isinstance(node, TransformNode):
+            return node
+        for child in node.children:
+            if isinstance(child, TransformNode):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _get_explored(self, unit: SimNode) -> set[tuple[int, int]]:
+        vis = self._find_visibility()
+        if vis is None:
+            return set()
+        nation = self._get_nation(unit)
+        if nation is None:
+            return set()
+        return vis.visible_tiles.get(id(nation), set())
+
+    # ------------------------------------------------------------------
+    def _get_nation(self, node: SimNode) -> NationNode | None:
+        cur = node.parent
+        while cur is not None:
+            if isinstance(cur, NationNode):
+                return cur
+            cur = cur.parent
+        return None
+
+    # ------------------------------------------------------------------
+    def _find_visibility(self) -> VisibilitySystem | None:
+        node = self
+        while node.parent is not None:
+            node = node.parent
+        for child in node.children:
+            if isinstance(child, VisibilitySystem):
+                return child
+        return None
+
+
+register_node_type("AISystem", AISystem)

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,26 @@
+from nodes.world import WorldNode
+from nodes.worker import WorkerNode
+from nodes.resource import ResourceNode
+from nodes.transform import TransformNode
+from nodes.terrain import TerrainNode
+from systems.pathfinding import PathfindingSystem
+from systems.ai import AISystem
+
+
+def test_idle_worker_receives_task():
+    world = WorldNode(width=5, height=5)
+    terrain = TerrainNode(parent=world, tiles=[["plain"] * 5 for _ in range(5)])
+    PathfindingSystem(parent=world, terrain=terrain)
+    AISystem(parent=world)
+
+    worker = WorkerNode(parent=world)
+    TransformNode(parent=worker, position=[0, 0])
+
+    resource = ResourceNode(parent=world, kind="wood", quantity=10)
+    TransformNode(parent=resource, position=[3, 0])
+
+    # Worker becomes idle
+    worker.emit("unit_idle", {})
+
+    assert worker.target == [3, 0]
+    assert worker.state == "moving"


### PR DESCRIPTION
## Summary
- implement `WorkerNode.find_task` using pathfinding to target nearest resource
- add `AISystem` reacting to `unit_idle` and exploring unknown tiles
- document worker tasks and AI in global spec and cover with tests

## Testing
- `pytest tests/test_ai.py tests/test_worker_node.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3724188908330ae02af0e338156b5