### PR TITLE
Handle building attacks and strategic defeat conditions

### DIFF
--- a/global_spec.md
+++ b/global_spec.md
@@ -76,8 +76,9 @@ Les nœuds représentent toutes les entités du monde (unités, bâtiments, stoc
 | Attribut      | Description                               |
 |---------------|-------------------------------------------|
 | `type`        | Type de bâtiment (ferme, tour, entrepôt). |
-| `capacity`    | Quantité maximale d'unités ou de ressources.
+| `capacity`    | Quantité maximale d'unités ou de ressources. |
 | `hit_points`  | Points de vie pour les combats.           |
+| `strategic`   | Sa destruction peut entraîner la défaite. |
 
 ### `ResourceNode`
 | Attribut        | Description                                          |
@@ -139,6 +140,10 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 - Garantissent la cohérence des unités de temps et d'espace.
 - Conversions explicites entre mètres et tuiles.
 
+### `VictorySystem`
+- Détecte la capture de la capitale et l'effondrement moral.
+- Écoute `building_destroyed` pour déclarer la défaite lorsqu'un bâtiment stratégique est perdu.
+
 ---
 
 ## Événements principaux
@@ -151,6 +156,7 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 | `resource_consumed`    | Consommation de ressource.                             |
 | `unit_move`            | Déplacement d'une unité vers une cible.                |
 | `attack_building`      | Cible un bâtiment; peut mener à `building_destroyed`.  |
+| `building_destroyed`   | Bâtiment détruit, potentielle condition de défaite.   |
 
 ---
 

--- a/nodes/building.py
+++ b/nodes/building.py
@@ -16,13 +16,24 @@ class BuildingNode(SimNode):
         Maximum capacity of units or resources handled by the building.
     hit_points:
         Structural durability used in combat interactions.
+    strategic:
+        When ``True`` the loss of this building can trigger defeat
+        conditions.
     """
 
-    def __init__(self, type: str, capacity: int = 0, hit_points: int = 100, **kwargs) -> None:
+    def __init__(
+        self,
+        type: str,
+        capacity: int = 0,
+        hit_points: int = 100,
+        strategic: bool = False,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.type = type
         self.capacity = capacity
         self.hit_points = hit_points
+        self.strategic = strategic
 
 
 register_node_type("BuildingNode", BuildingNode)

--- a/tests/test_combat_building.py
+++ b/tests/test_combat_building.py
@@ -1,0 +1,20 @@
+from nodes.world import WorldNode
+from nodes.building import BuildingNode
+from systems.combat import CombatSystem
+
+
+def test_building_destroyed_after_sufficient_damage():
+    world = WorldNode()
+    CombatSystem(parent=world)
+    building = BuildingNode(parent=world, type="warehouse", hit_points=50)
+    events = []
+    building.on_event("building_destroyed", lambda _o, _e, p: events.append(p))
+
+    world.emit("attack_building", {"target": building, "damage": 30})
+    assert building.hit_points == 20
+    assert building in world.children
+
+    world.emit("attack_building", {"target": building, "damage": 20})
+    assert building.hit_points == 0
+    assert events and events[0]["building"] == "warehouse"
+    assert building not in world.children


### PR DESCRIPTION
## Summary
- allow CombatSystem to damage and destroy buildings via `attack_building`
- mark buildings as strategic and have VictorySystem defeat nations when they fall
- document new building mechanics and add tests for building destruction

## Testing
- `pytest tests/test_combat_building.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a377e357208330a492c4995c3e95ff