### PR TITLE
Expose node classes for plugin registration

### DIFF
--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -1,0 +1,12 @@
+"""Expose core node classes and trigger plugin registration."""
+
+from .building import BuildingNode  # noqa: F401
+from .resource import ResourceNode  # noqa: F401
+from .worker import WorkerNode  # noqa: F401
+
+__all__ = [
+    "BuildingNode",
+    "ResourceNode",
+    "WorkerNode",
+]
+


### PR DESCRIPTION
## Summary
- Expose BuildingNode, ResourceNode, and WorkerNode through `nodes` package
- Importing `nodes` now registers these node types via plugin system

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a37f463c608330bfb843a0dff4188d