### PR TITLE
Center main nation's capital

### DIFF
--- a/example/plain_map_config.json
+++ b/example/plain_map_config.json
@@ -116,7 +116,7 @@
         "id": "north",
         "config": {
           "capital_position": [
-            1000,
+            5000,
             3000
           ],
           "morale": 100
@@ -134,7 +134,7 @@
                 "type": "TransformNode",
                 "config": {
                   "position": [
-                    1000,
+                    5000,
                     3000
                   ]
                 }
@@ -151,7 +151,7 @@
                     "type": "TransformNode",
                     "config": {
                       "position": [
-                        1000,
+                        5000,
                         3000
                       ]
                     }
@@ -174,7 +174,7 @@
                         "type": "TransformNode",
                         "config": {
                           "position": [
-                            1000,
+                            5000,
                             3000
                           ]
                         }

--- a/example/war_simulation_config.json
+++ b/example/war_simulation_config.json
@@ -116,7 +116,7 @@
         "id": "north",
         "config": {
           "capital_position": [
-            1000,
+            5000,
             3000
           ],
           "morale": 100
@@ -134,7 +134,7 @@
                 "type": "TransformNode",
                 "config": {
                   "position": [
-                    1000,
+                    5000,
                     3000
                   ]
                 }
@@ -151,7 +151,7 @@
                     "type": "TransformNode",
                     "config": {
                       "position": [
-                        1000,
+                        5000,
                         3000
                       ]
                     }
@@ -174,7 +174,7 @@
                         "type": "TransformNode",
                         "config": {
                           "position": [
-                            1000,
+                            5000,
                             3000
                           ]
                         }

--- a/tests/test_capital_transform_sync.py
+++ b/tests/test_capital_transform_sync.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import json
+
+def test_north_capital_and_transform_match_center():
+    config_path = Path(__file__).resolve().parents[1] / "example" / "war_simulation_config.json"
+    with config_path.open(encoding="utf8") as fh:
+        data = json.load(fh)
+    world = data["war_world"]
+    width = world["config"]["width"]
+    height = world["config"]["height"]
+    center = [width // 2, height // 2]
+
+    north = next(child for child in world["children"] if child.get("id") == "north")
+    assert north["config"]["capital_position"] == center
+
+    general = next(child for child in north["children"] if child.get("id") == "north_general")
+    transform = next(child for child in general["children"] if child.get("type") == "TransformNode")
+    assert transform["config"]["position"] == center


### PR DESCRIPTION
## Summary
- Center the main nation's capital and initial positions on the map
- Add regression test ensuring capital and TransformNode stay aligned

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a382f6ac8483308bdb85469def085f