### PR TITLE
feat: spawn workers at capitals and refine AI search

### DIFF
--- a/systems/ai.py
+++ b/systems/ai.py
@@ -8,15 +8,23 @@ from core.plugins import register_node_type
 from nodes.worker import WorkerNode
 from nodes.transform import TransformNode
 from nodes.nation import NationNode
+from nodes.unit import UnitNode
+from nodes.terrain import TerrainNode
 from systems.visibility import VisibilitySystem
 
 
 class AISystem(SystemNode):
     """Assign tasks to idle workers and explore unknown territory."""
 
-    def __init__(self, exploration_radius: int = 5, **kwargs) -> None:
+    def __init__(
+        self,
+        exploration_radius: int = 5,
+        capital_min_radius: int = 0,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         self.exploration_radius = exploration_radius
+        self.capital_min_radius = capital_min_radius
         self.on_event("unit_idle", self._on_unit_idle)
 
     # ------------------------------------------------------------------
@@ -39,16 +47,27 @@ class AISystem(SystemNode):
                 pos = (x0 + dx, y0 + dy)
                 if pos in explored:
                     continue
+                if not self._beyond_capital_radius(origin, pos):
+                    continue
+                if not self._is_free(pos):
+                    continue
                 origin.target = [pos[0], pos[1]]
                 origin.state = "moving"
                 origin.emit("unit_move", {"to": origin.target}, direction="up")
                 return
         # fallback random move if everything explored
-        dx = random.randint(-radius, radius)
-        dy = random.randint(-radius, radius)
-        origin.target = [x0 + dx, y0 + dy]
-        origin.state = "moving"
-        origin.emit("unit_move", {"to": origin.target}, direction="up")
+        for _ in range(10):
+            dx = random.randint(-radius, radius)
+            dy = random.randint(-radius, radius)
+            pos = (x0 + dx, y0 + dy)
+            if not self._beyond_capital_radius(origin, pos):
+                continue
+            if not self._is_free(pos):
+                continue
+            origin.target = [pos[0], pos[1]]
+            origin.state = "moving"
+            origin.emit("unit_move", {"to": origin.target}, direction="up")
+            return
 
     # ------------------------------------------------------------------
     def _get_transform(self, node: SimNode) -> TransformNode | None:
@@ -77,6 +96,53 @@ class AISystem(SystemNode):
                 return cur
             cur = cur.parent
         return None
+
+    # ------------------------------------------------------------------
+    def _beyond_capital_radius(
+        self, unit: SimNode, pos: tuple[int, int]
+    ) -> bool:
+        nation = self._get_nation(unit)
+        if nation is None:
+            return True
+        cx, cy = nation.capital_position
+        dx = pos[0] - cx
+        dy = pos[1] - cy
+        return dx * dx + dy * dy >= self.capital_min_radius * self.capital_min_radius
+
+    # ------------------------------------------------------------------
+    def _iter_units(self, node: SimNode):
+        for child in node.children:
+            if isinstance(child, UnitNode):
+                yield child
+            yield from self._iter_units(child)
+
+    # ------------------------------------------------------------------
+    def _find_terrain(self) -> TerrainNode | None:
+        node = self
+        while node.parent is not None:
+            node = node.parent
+        for child in node.children:
+            if isinstance(child, TerrainNode):
+                return child
+        return None
+
+    # ------------------------------------------------------------------
+    def _is_free(self, pos: tuple[int, int]) -> bool:
+        terrain = self._find_terrain()
+        if terrain is not None and terrain.is_obstacle(pos[0], pos[1]):
+            return False
+        root = self
+        while root.parent is not None:
+            root = root.parent
+        for unit in self._iter_units(root):
+            tr = self._get_transform(unit)
+            if tr is None:
+                continue
+            ux = int(round(tr.position[0]))
+            uy = int(round(tr.position[1]))
+            if (ux, uy) == pos:
+                return False
+        return True
 
     # ------------------------------------------------------------------
     def _find_visibility(self) -> VisibilitySystem | None:

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,6 +1,8 @@
 from nodes.world import WorldNode
 from nodes.worker import WorkerNode
 from nodes.transform import TransformNode
+from nodes.nation import NationNode
+from nodes.terrain import TerrainNode
 from systems.ai import AISystem
 
 
@@ -18,3 +20,21 @@ def test_idle_worker_explores_unknown_tiles():
     # AI should send the worker exploring away from origin
     assert worker.state == "moving"
     assert worker.target == [-2, 0]
+
+
+def test_ai_respects_capital_radius_and_free_tiles():
+    world = WorldNode(width=20, height=20)
+    terrain = TerrainNode(tiles=[[0] * 20 for _ in range(20)], obstacles=[[7, 10]])
+    world.add_child(terrain)
+    nation = NationNode(parent=world, morale=100, capital_position=[10, 10])
+    worker = WorkerNode(parent=nation, state="exploring")
+    TransformNode(parent=worker, position=[10, 10])
+    blocker = WorkerNode(parent=nation, state="idle")
+    TransformNode(parent=blocker, position=[8, 8])
+    ai = AISystem(parent=world, exploration_radius=3, capital_min_radius=2)
+    worker.emit("unit_idle", {})
+    assert worker.state == "moving"
+    cx, cy = nation.capital_position
+    tx, ty = worker.target
+    assert (tx - cx) * (tx - cx) + (ty - cy) * (ty - cy) >= 4
+    assert worker.target not in ([7, 10], [8, 8])

--- a/tests/test_worker_spawn.py
+++ b/tests/test_worker_spawn.py
@@ -1,0 +1,21 @@
+from nodes.world import WorldNode
+from nodes.nation import NationNode
+from nodes.general import GeneralNode
+from nodes.transform import TransformNode
+from nodes.worker import WorkerNode
+from simulation.war.war_loader import _spawn_armies
+
+
+def test_spawn_armies_adds_workers():
+    world = WorldNode(width=100, height=100)
+    nation = NationNode(parent=world, morale=100, capital_position=[50, 50])
+    general = GeneralNode(parent=nation, style="balanced")
+    TransformNode(parent=general, position=[50, 50])
+    _spawn_armies(world, dispersion_radius=0, soldiers_per_dot=1, bodyguard_size=1)
+    workers = [c for c in nation.children if isinstance(c, WorkerNode)]
+    assert len(workers) == 3
+    for w in workers:
+        assert w.state == "exploring"
+        tr = next(c for c in w.children if isinstance(c, TransformNode))
+        assert tr.position == [50, 50]
+


### PR DESCRIPTION
## Summary
- spawn three exploring workers at each nation's capital and attach AI system
- enhance AISystem to avoid obstacles and stay beyond a minimum capital radius
- cover worker spawning and AI exploration with new tests

## Testing
- `python -m flake8` *(fails: No module named flake8)*
- `python -m mypy .` *(fails: Source file found twice under different module names)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3843a0c84833099e4625d69433286