### PR TITLE
Add builder node for city and road construction

### DIFF
--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -3,10 +3,12 @@
 from .building import BuildingNode  # noqa: F401
 from .resource import ResourceNode  # noqa: F401
 from .worker import WorkerNode  # noqa: F401
+from .builder import BuilderNode  # noqa: F401
 
 __all__ = [
     "BuildingNode",
     "ResourceNode",
     "WorkerNode",
+    "BuilderNode",
 ]
 

--- a/nodes/builder.py
+++ b/nodes/builder.py
@@ -1,0 +1,67 @@
+"""Builder unit node capable of establishing new cities and roads."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from core.plugins import register_node_type
+from core.simnode import SimNode
+from nodes.worker import WorkerNode
+from nodes.building import BuildingNode
+from nodes.transform import TransformNode
+
+
+class BuilderNode(WorkerNode):
+    """Worker specialised in constructing cities and connecting roads."""
+
+    def build_city(
+        self,
+        position: Iterable[int] | tuple[int, int],
+        last_infrastructure: SimNode,
+    ) -> BuildingNode | None:
+        """Create a city at ``position`` and link it to ``last_infrastructure``.
+
+        A :class:`BuildingNode` of type ``"city"`` is created at the supplied
+        coordinates. For each intermediate tile on the path between the last
+        infrastructure and the new city, a ``BuildingNode`` of type ``"road"``
+        is added as well.
+
+        Returns the newly created city node or ``None`` if the operation could
+        not be completed (e.g. missing transforms or pathfinder).
+        """
+
+        # Resolve root of the simulation tree
+        root = self
+        while root.parent is not None:
+            root = root.parent
+
+        # Determine start position from the last infrastructure
+        start_tr = self._get_transform(last_infrastructure)
+        if start_tr is None:
+            return None
+
+        goal_x, goal_y = int(round(position[0])), int(round(position[1]))
+
+        # Compute path using the existing pathfinding system if available
+        pathfinder = self._find_pathfinder()
+        path: list[tuple[int, int]] = []
+        if pathfinder is not None:
+            start = (
+                int(round(start_tr.position[0])),
+                int(round(start_tr.position[1])),
+            )
+            path = pathfinder.find_path(start, (goal_x, goal_y))
+
+        # Create the city at the goal position
+        city = BuildingNode(parent=root, type="city")
+        TransformNode(parent=city, position=[goal_x, goal_y])
+
+        # Create road segments along the path (excluding endpoints)
+        if len(path) > 2:
+            for x, y in path[1:-1]:
+                road = BuildingNode(parent=root, type="road")
+                TransformNode(parent=road, position=[x, y])
+
+        return city
+
+
+register_node_type("BuilderNode", BuilderNode)

--- a/tests/test_builder_node.py
+++ b/tests/test_builder_node.py
@@ -1,0 +1,35 @@
+from nodes.builder import BuilderNode
+from nodes.building import BuildingNode
+from nodes.world import WorldNode
+from nodes.transform import TransformNode
+from nodes.terrain import TerrainNode
+from systems.pathfinding import PathfindingSystem
+
+
+def test_builder_creates_city_and_roads():
+    world = WorldNode(name="world")
+    terrain = TerrainNode(parent=world, tiles=[["plain"] * 5])
+    pathfinder = PathfindingSystem(parent=world, terrain=terrain)
+
+    last = BuildingNode(parent=world, type="capital")
+    TransformNode(parent=last, position=[0, 0])
+
+    builder = BuilderNode(parent=world)
+    city = builder.build_city([4, 0], last)
+
+    # check city created at correct location
+    assert isinstance(city, BuildingNode)
+    assert city.type == "city"
+    city_pos = None
+    for child in city.children:
+        if isinstance(child, TransformNode):
+            city_pos = child.position
+    assert city_pos == [4, 0]
+
+    # ensure roads connect intermediate tiles
+    road_positions = sorted(
+        child.children[0].position
+        for child in world.children
+        if isinstance(child, BuildingNode) and child.type == "road"
+    )
+    assert road_positions == [[1, 0], [2, 0], [3, 0]]


### PR DESCRIPTION
## Summary
- add `BuilderNode` to construct new cities and lay roads to the previous infrastructure
- expose `BuilderNode` in `nodes.__init__`
- add tests ensuring city and road nodes are created correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3862e03508330b2def4a3a4ea3dac