### PR TITLE
Reset builder to exploring after construction

### DIFF
--- a/tests/test_builder_node.py
+++ b/tests/test_builder_node.py
@@ -33,3 +33,33 @@ def test_builder_creates_city_and_roads():
         if isinstance(child, BuildingNode) and child.type == "road"
     )
     assert road_positions == [[1, 0], [2, 0], [3, 0]]
+
+    # builder should resume exploration after construction
+    assert builder.state == "exploring"
+
+
+def test_builder_build_cities_respects_city_limit():
+    world = WorldNode(name="world")
+    terrain = TerrainNode(parent=world, tiles=[["plain"] * 10])
+    PathfindingSystem(parent=world, terrain=terrain)
+
+    last = BuildingNode(parent=world, type="capital")
+    TransformNode(parent=last, position=[0, 0])
+
+    builder = BuilderNode(parent=world)
+    cities = builder.build_cities([(4, 0), (8, 0)], last, max_cities=1)
+    assert len(cities) == 1
+    assert builder.state == "exploring"
+
+
+def test_builder_build_cities_respects_coverage_limit():
+    world = WorldNode(name="world")
+    terrain = TerrainNode(parent=world, tiles=[["plain"] * 10])
+    PathfindingSystem(parent=world, terrain=terrain)
+
+    last = BuildingNode(parent=world, type="capital")
+    TransformNode(parent=last, position=[0, 0])
+
+    builder = BuilderNode(parent=world)
+    cities = builder.build_cities([(4, 0), (8, 0)], last, max_coverage=5)
+    assert len(cities) == 1


### PR DESCRIPTION
## Summary
- Reset builder to `exploring` state after building city and roads
- Add `build_cities` helper to repeat construction until city or coverage limit
- Test builder state resets and limit enforcement

## Testing
- `python -m pytest`
- `python -m flake8` *(fails: No module named flake8)*
- `python -m mypy --exclude "tools/terrain_generators.py" .` *(fails: multiple attribute/type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a387b080e48330b33e2fc3bf6c3af4