### PR TITLE
Fix viewer dt handling and add flat 1km war map

### DIFF
--- a/example/flat_1km_config.json
+++ b/example/flat_1km_config.json
@@ -1,0 +1,41 @@
+{
+  "war_world": {
+    "type": "WorldNode",
+    "config": {
+      "width": 1000,
+      "height": 1000,
+      "seed": 1
+    },
+    "children": [
+      { "type": "TimeSystem", "id": "time", "config": { "time_scale": 48 } },
+      { "type": "MovementSystem", "id": "movement", "config": { "terrain": "terrain" } },
+      { "type": "CombatSystem", "id": "combat", "config": { "terrain": "terrain" } },
+      { "type": "MoralSystem", "id": "moral" },
+      { "type": "VictorySystem", "id": "victory", "config": { "capture_unit_threshold": 1 } },
+      { "type": "LoggingSystem", "id": "logger", "config": { "events": ["unit_moved"] } },
+      { "type": "TerrainNode", "id": "terrain", "config": {
+          "grid_type": "square",
+          "tiles": [["plain"]],
+          "obstacles": [],
+          "terrain_params": {
+            "rivers": [],
+            "lakes": [],
+            "forests": { "total_area_pct": 0, "clusters": 0, "cluster_spread": 0 },
+            "mountains": { "total_area_pct": 0 },
+            "swamp_desert": { "swamp_pct": 0, "desert_pct": 0, "clumpiness": 0 },
+            "obstacle_altitude_threshold": 1.0
+          }
+        }
+      },
+      { "type": "NationNode", "id": "north", "config": { "capital_position": [500, 500], "morale": 100 },
+        "children": [
+          { "type": "GeneralNode", "id": "north_general", "config": { "style": "balanced", "flank_success_chance": 0.25 },
+            "children": [
+              { "type": "TransformNode", "config": { "position": [500, 500] } }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/simulation/war/viewer_loop.py
+++ b/simulation/war/viewer_loop.py
@@ -113,13 +113,13 @@ def run(viewer: str = "pygame") -> None:
                     cy = viewer.offset_y + viewer.view_height / (2 * prev)
                     viewer.offset_x = cx - viewer.view_width / (2 * viewer.scale)
                     viewer.offset_y = cy - viewer.view_height / (2 * viewer.scale)
-                elif event.key == pygame.K_h:
+                elif event.key == pygame.K_q:
                     viewer.offset_x -= viewer.view_width * 0.1 / viewer.scale
-                elif event.key == pygame.K_l:
+                elif event.key == pygame.K_d:
                     viewer.offset_x += viewer.view_width * 0.1 / viewer.scale
-                elif event.key == pygame.K_j:
+                elif event.key == pygame.K_s:
                     viewer.offset_y += viewer.view_height * 0.1 / viewer.scale
-                elif event.key == pygame.K_k:
+                elif event.key == pygame.K_z:
                     viewer.offset_y -= viewer.view_height * 0.1 / viewer.scale
                 elif event.key == pygame.K_b:
                     viewer.set_render_params(show_role_rings=not viewer.show_role_rings)
@@ -188,6 +188,6 @@ def run(viewer: str = "pygame") -> None:
         viewer.process_events(events)
         dt = clock.tick(FPS) / 1000.0
         world.update(0 if paused else dt * TIME_SCALE)
-        viewer.render()
+        viewer.render(dt)
 
     pygame.quit()

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -82,9 +82,7 @@ def load_sim_params(path: str) -> dict:
 def setup_world(config_file: str | None = None, settings_file: str | None = None):
     """Load the world and simulation parameters."""
 
-    config_file = config_file or (
-        sys.argv[1] if len(sys.argv) > 1 else "example/plain_map_config.json"
-    )
+    config_file = config_file or "example/flat_1km_config.json"
     world = load_simulation_from_file(config_file)
 
     AISystem(parent=world, capital_min_radius=100)

--- a/systems/moderngl_viewer.py
+++ b/systems/moderngl_viewer.py
@@ -44,8 +44,12 @@ class ModernGLViewerSystem(SystemNode, Viewer):
         """Update internal state (no-op for this simple viewer)."""
         pass
 
-    def render(self) -> None:  # pragma: no cover - requires OpenGL context
-        """Clear the screen using ModernGL and swap buffers."""
+    def render(self, dt: float = 0.0) -> None:  # pragma: no cover - requires OpenGL context
+        """Clear the screen using ModernGL and swap buffers.
+
+        The ``dt`` parameter is accepted for API compatibility with
+        :class:`pygame_viewer.PygameViewerSystem`.
+        """
         self.ctx.clear(0.1, 0.1, 0.1)
         pygame.display.flip()
 

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -65,8 +65,13 @@ class Viewer(Protocol):
     def update(self, dt: float) -> None:
         """Mettre à jour l'état interne sans effectuer de rendu."""
 
-    def render(self) -> None:
-        """Dessiner l'état courant à l'écran."""
+    def render(self, dt: float = 0.0) -> None:
+        """Dessiner l'état courant à l'écran.
+
+        Le paramètre ``dt`` représente le temps simulé écoulé depuis le
+        précédent rendu et est fourni pour assurer la cohérence de
+        l'interface entre les différents moteurs d'affichage.
+        """
 
 
 class PygameViewerSystem(SystemNode, Viewer):
@@ -371,8 +376,14 @@ class PygameViewerSystem(SystemNode, Viewer):
         """Mettre à jour l'état interne sans rendu."""
         pass
 
-    def render(self) -> None:
-        """Render the current simulation state."""
+    def render(self, dt: float = 0.0) -> None:
+        """Render the current simulation state.
+
+        Parameters
+        ----------
+        dt:
+            Simulation time elapsed since the previous frame.
+        """
         start_time = time.perf_counter()
         self.screen.fill((30, 30, 30))
 
@@ -498,9 +509,12 @@ class PygameViewerSystem(SystemNode, Viewer):
             hours = int(time_sys.current_time // 3600) % 24
             minutes = int((time_sys.current_time % 3600) // 60)
             time_text = f"{hours:02d}:{minutes:02d}"
+            day = int(
+                time_sys.current_tick * time_sys.tick_duration // time_sys.day_length
+            ) + 1
             lines.insert(0, f"Phase: {time_sys.phase}")
             lines.insert(0, f"Tick: {time_sys.current_tick}")
-            lines.insert(0, time_text)
+            lines.insert(0, f"Day: {day} {time_text}")
         lines.insert(0, f"Units: {unit_count}")
 
         line_height = self.font.get_linesize()
@@ -545,7 +559,7 @@ class PygameViewerSystem(SystemNode, Viewer):
             " Space: pause/resume",
             " +/- : change speed",
             " [: zoom out, ]: zoom in",
-            " H/J/K/L: pan view",
+            " Z/Q/S/D: pan view",
             " V: toggle frame logging",
         ]
         controls.extend(self.extra_info)


### PR DESCRIPTION
## Summary
- accept `dt` in viewer backends to avoid NameError during rendering
- map camera controls to ZQSD and show day/time in sidebar
- add flat 1km war map config and load it by default

## Testing
- `pytest`
- `python run_war.py --viewer pygame` (manually interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68a3897132008330b53050897ee1abe2