### PR TITLE
Add colony viewer entry point and example configuration

### DIFF
--- a/example/colony_config.json
+++ b/example/colony_config.json
@@ -1,0 +1,44 @@
+{
+  "war_world": {
+    "type": "WorldNode",
+    "config": {
+      "width": 1000,
+      "height": 1000,
+      "seed": 1
+    },
+    "children": [
+      {
+        "type": "TerrainNode",
+        "id": "terrain",
+        "config": {
+          "grid_type": "square",
+          "tiles": [["plain"]],
+          "obstacles": [],
+          "terrain_params": {
+            "rivers": [],
+            "lakes": [],
+            "forests": { "total_area_pct": 0, "clusters": 0, "cluster_spread": 0 },
+            "mountains": { "total_area_pct": 0 },
+            "swamp_desert": { "swamp_pct": 0, "desert_pct": 0, "clumpiness": 0 },
+            "obstacle_altitude_threshold": 1.0
+          }
+        }
+      },
+      {
+        "type": "NationNode",
+        "id": "north",
+        "config": { "capital_position": [500, 500], "morale": 100 },
+        "children": [
+          {
+            "type": "GeneralNode",
+            "id": "north_general",
+            "config": { "style": "balanced", "flank_success_chance": 0.25 },
+            "children": [
+              { "type": "TransformNode", "config": { "position": [500, 500] } }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/run_colony.py
+++ b/run_colony.py
@@ -1,0 +1,39 @@
+"""Entry point for the colony simulation viewer with optional terrain caching."""
+from __future__ import annotations
+
+import argparse
+import os
+from typing import List
+
+__all__ = ["run"]
+
+
+def run(argv: List[str] | None = None) -> None:  # pragma: no cover - manual launch
+    parser = argparse.ArgumentParser(description="Colony simulation viewer")
+    parser.add_argument(
+        "--viewer",
+        choices=["pygame", "moderngl"],
+        default="pygame",
+        help="Backend graphique à utiliser",
+    )
+    args = parser.parse_args(argv)
+
+    cache_path = os.path.join(os.path.dirname(__file__), "terrain_cache.pkl")
+    if os.path.exists(cache_path):
+        os.environ.setdefault("WAR_TERRAIN_CACHE", cache_path)
+
+    from simulation.war import war_loader
+
+    _orig_setup_world = war_loader.setup_world
+
+    def _setup_world(config_file: str | None = None, settings_file: str | None = None):
+        return _orig_setup_world(config_file or "example/colony_config.json", settings_file)
+
+    war_loader.setup_world = _setup_world
+
+    from simulation.war.viewer_loop import run as viewer_run
+    viewer_run(viewer=args.viewer)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual launch
+    run()


### PR DESCRIPTION
## Summary
- Add a `run_colony.py` script to launch the viewer with colony defaults and terrain cache support
- Provide `example/colony_config.json` with a simple world, terrain, and general at `[500, 500]`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a38e380cc48330937f170b1d0a6d3f