### PR TITLE
Spawn only builder units at capitals

### DIFF
--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
-import math
 import os
-import random
 import pickle
 import sys
 
@@ -14,16 +12,13 @@ from core.loader import load_simulation_from_file
 from core.plugins import load_plugins
 
 from simulation.war.nodes import (
-    ArmyNode,
-    BodyguardUnitNode,
     GeneralNode,
     NationNode,
-    OfficerNode,
     StrategistNode,
     TerrainNode,
     TransformNode,
-    UnitNode,
 )
+from nodes.builder import BuilderNode
 from nodes.worker import WorkerNode
 from systems.ai import AISystem
 from simulation.war.presets import DEFAULT_SIM_PARAMS
@@ -53,6 +48,7 @@ def load_plugins_for_war() -> None:
             "nodes.bodyguard",
             "nodes.building",
             "nodes.resource",
+            "nodes.builder",
             "nodes.worker",
             "systems.movement",
             "systems.combat",
@@ -103,19 +99,6 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     return world, terrain_node, pathfinder
 
 
-def _pos_around(cx: float, cy: float, dispersion_radius: float) -> list[float]:
-    if dispersion_radius <= 0:
-        return [cx, cy]
-    angle = random.uniform(0, 2 * math.pi)
-    r = random.uniform(0, dispersion_radius)
-    return [cx + math.cos(angle) * r, cy + math.sin(angle) * r]
-
-
-def _round_size(size: int, soldiers_per_dot: int) -> int:
-    mul = max(1, soldiers_per_dot)
-    return max(mul, int(math.ceil(size / mul)) * mul)
-
-
 def _spawn_armies(
     world,
     dispersion_radius: float,
@@ -149,62 +132,15 @@ def _spawn_armies(
         general.add_child(strategist)
 
         for i in range(3):
-            worker = WorkerNode(
-                name=f"{nation.name}_worker_{i+1}",
+            builder = BuilderNode(
+                name=f"{nation.name}_builder_{i+1}",
                 state="exploring",
                 speed=1.0,
                 morale=100,
             )
-            worker.add_child(TransformNode(position=list(center)))
-            nation.add_child(worker)
-            worker.emit("unit_idle", {})
-
-        for i in range(5):
-            size = _round_size(bodyguard_size, soldiers_per_dot)
-            bg = BodyguardUnitNode(
-                name=f"{nation.name}_bodyguard_{i+1}",
-                size=size,
-                state="idle",
-                speed=1.0,
-                morale=100,
-                vision_radius_m=sim_params.get("vision_radius_m", 100.0),
-            )
-            bg.add_child(TransformNode(position=_pos_around(*center, dispersion_radius)))
-            general.add_child(bg)
-
-        army = ArmyNode(name=f"{nation.name}_army", goal="advance", size=0)
-        army.add_child(TransformNode(position=list(center)))
-        total_units = 0
-        enemies = [n for n in nations if n is not nation]
-        target_cap = enemies[0].capital_position if enemies else [width / 2, height / 2]
-        unit_size = _round_size(sim_params.get("unit_size", 5), soldiers_per_dot)
-        for i in range(5):
-            officer = OfficerNode(name=f"{nation.name}_officer_{i+1}")
-            officer.add_child(TransformNode(position=_pos_around(*center, dispersion_radius)))
-            for j in range(4):
-                unit_target = list(target_cap) if i == 0 else None
-                unit = UnitNode(
-                    name=f"{nation.name}_unit_{i+1}_{j+1}",
-                    size=unit_size,
-                    state="idle",
-                    speed=1.0,
-                    morale=100,
-                    target=unit_target,
-                    vision_radius_m=sim_params.get("vision_radius_m", 100.0),
-                )
-                pos = _pos_around(*center, dispersion_radius)
-                unit.add_child(TransformNode(position=pos))
-                if i == 0 and unit_target is not None and pathfinder is not None:
-                    start = (int(round(pos[0])), int(round(pos[1])))
-                    goal = (int(round(unit_target[0])), int(round(unit_target[1])))
-                    path = pathfinder.find_path(start, goal)
-                    if len(path) > 1:
-                        unit._path = path[1:]
-                officer.add_child(unit)
-                total_units += 1
-            army.add_child(officer)
-        army.size = total_units
-        general.add_child(army)
+            builder.add_child(TransformNode(position=list(center)))
+            nation.add_child(builder)
+            builder.emit("unit_idle", {})
 
 
 

--- a/tests/test_army_ai_movement.py
+++ b/tests/test_army_ai_movement.py
@@ -8,14 +8,14 @@ from nodes.terrain import TerrainNode
 from nodes.nation import NationNode
 from nodes.general import GeneralNode
 from nodes.army import ArmyNode
-from nodes.unit import UnitNode
+from nodes.builder import BuilderNode
 from nodes.transform import TransformNode
 from systems.movement import MovementSystem
 from systems.pathfinding import PathfindingSystem
 from run_war import _spawn_armies
 
 
-def test_cautious_advance_and_reserves():
+def test_spawn_armies_creates_only_builders():
     random.seed(0)
     world = WorldNode(width=3, height=3)
     terrain = TerrainNode(parent=world, tiles=[["plain"] * 3 for _ in range(3)], obstacles=[[1, 0]])
@@ -32,16 +32,10 @@ def test_cautious_advance_and_reserves():
 
     _spawn_armies(world, 0, 1, 1, pathfinder)
 
-    army = next(c for c in g_north.children if isinstance(c, ArmyNode))
-    frontline = next(c for c in army.get_officers()[0].children if isinstance(c, UnitNode))
-    reserve = next(c for c in army.get_officers()[1].children if isinstance(c, UnitNode))
-
-    assert reserve.target is None
-    assert getattr(frontline, "_path", None)
-    assert frontline.target == [2, 2]
-
-    world.update(1.0)
-    front_tr = next(c for c in frontline.children if isinstance(c, TransformNode))
-    reserve_tr = next(c for c in reserve.children if isinstance(c, TransformNode))
-    assert front_tr.position == [0.0, 1.0]
-    assert reserve_tr.position == [0.0, 0.0]
+    assert not any(isinstance(c, ArmyNode) for c in g_north.children)
+    builders = [c for c in north.children if isinstance(c, BuilderNode)]
+    assert len(builders) == 3
+    for b in builders:
+        tr = next(c for c in b.children if isinstance(c, TransformNode))
+        assert tr.position == [0, 0]
+        assert b.state == "exploring"

--- a/tests/test_sim_params.py
+++ b/tests/test_sim_params.py
@@ -8,8 +8,7 @@ from nodes.world import WorldNode
 from nodes.nation import NationNode
 from nodes.general import GeneralNode
 from nodes.transform import TransformNode
-from nodes.army import ArmyNode
-from nodes.unit import UnitNode
+from nodes.builder import BuilderNode
 
 from run_war import load_sim_params, _spawn_armies, sim_params
 
@@ -26,7 +25,7 @@ def test_load_sim_params(tmp_path):
     assert params["dispersion"] == 200.0
 
 
-def test_spawn_armies_respects_sim_params():
+def test_spawn_armies_creates_builders():
     random.seed(0)
     world = WorldNode(width=3, height=3)
     north = NationNode(parent=world, name="north", capital_position=[0, 0], morale=100)
@@ -42,10 +41,10 @@ def test_spawn_armies_respects_sim_params():
         sim_params["vision_radius_m"] = 50.0
         _spawn_armies(world, 0, sim_params["soldiers_per_dot"], sim_params["bodyguard_size"], None)
 
-        army = next(c for c in g_north.children if isinstance(c, ArmyNode))
-        unit = next(c for c in army.get_officers()[0].children if isinstance(c, UnitNode))
-        assert unit.size == 20
-        assert unit.vision_radius_m == 50.0
+        builders = [c for c in north.children if isinstance(c, BuilderNode)]
+        assert len(builders) == 3
+        for b in builders:
+            assert b.state == "exploring"
     finally:
         sim_params.clear()
         sim_params.update(old_params)


### PR DESCRIPTION
## Summary
- spawn three builder units at each nation's capital and drop army/bodyguard creation
- load builder plugin for war simulation
- adjust tests to match builder-focused spawning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a38f13100c83308926d64c8e9c4021