### PR TITLE
Initialize nation last city at world load

### DIFF
--- a/systems/ai.py
+++ b/systems/ai.py
@@ -29,6 +29,21 @@ class AISystem(SystemNode):
         self.capital_min_radius = capital_min_radius
         self.on_event("unit_idle", self._on_unit_idle)
         self._last_city: dict[int, SimNode] = {}
+        self._init_last_cities()
+
+    # ------------------------------------------------------------------
+    def _init_last_cities(self) -> None:
+        """Seed ``_last_city`` with each nation's capital."""
+        root = self
+        while root.parent is not None:
+            root = root.parent
+        for nation in self._iter_nations(root):
+            key = id(nation)
+            if key in self._last_city:
+                continue
+            city = BuildingNode(parent=root, type="city")
+            TransformNode(parent=city, position=list(nation.capital_position))
+            self._last_city[key] = city
 
     # ------------------------------------------------------------------
     def _on_unit_idle(self, origin: SimNode, _event: str, _payload: dict) -> None:
@@ -144,6 +159,13 @@ class AISystem(SystemNode):
             if isinstance(child, UnitNode):
                 yield child
             yield from self._iter_units(child)
+
+    # ------------------------------------------------------------------
+    def _iter_nations(self, node: SimNode):
+        for child in node.children:
+            if isinstance(child, NationNode):
+                yield child
+            yield from self._iter_nations(child)
 
     # ------------------------------------------------------------------
     def _find_terrain(self) -> TerrainNode | None:

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -57,3 +57,14 @@ def test_builder_constructs_city_when_idle_far_from_last():
                 positions.append(child.position)
     assert [3, 0] in positions
     assert builder.state == "moving"
+
+
+def test_ai_initializes_last_city_with_capital():
+    world = WorldNode(width=20, height=20)
+    nation = NationNode(parent=world, morale=100, capital_position=[5, 5])
+    ai = AISystem(parent=world, exploration_radius=2, capital_min_radius=2)
+    last = ai._last_city.get(id(nation))
+    assert isinstance(last, BuildingNode)
+    tr = next((c for c in last.children if isinstance(c, TransformNode)), None)
+    assert tr is not None
+    assert tr.position == [5, 5]


### PR DESCRIPTION
## Summary
- Seed AI system's last-city tracking with each nation's capital when the world is created
- Provide helper to iterate nations and track new cities after construction
- Add regression test ensuring capitals populate last-city mapping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3926355648330b484c5a38cfcdb8b