### PR TITLE
Simplify colony config and viewer controls

### DIFF
--- a/example/colony_config.json
+++ b/example/colony_config.json
@@ -27,12 +27,12 @@
       {
         "type": "NationNode",
         "id": "north",
-        "config": { "capital_position": [500, 500], "morale": 100 },
+        "config": { "capital_position": [500, 500] },
         "children": [
           {
             "type": "GeneralNode",
             "id": "north_general",
-            "config": { "style": "balanced", "flank_success_chance": 0.25 },
+            "config": { "style": "balanced" },
             "children": [
               { "type": "TransformNode", "config": { "position": [500, 500] } }
             ]


### PR DESCRIPTION
## Summary
- Strip war-only parameters from `example/colony_config.json`
- Remove army/terrain controls from the viewer, leaving only time and camera controls

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39345e7a48330ab1ac651966bfa00