### PR TITLE
Builder emits idle after city

### DIFF
--- a/nodes/builder.py
+++ b/nodes/builder.py
@@ -17,6 +17,8 @@ class BuilderNode(WorkerNode):
         self,
         position: Iterable[int] | tuple[int, int],
         last_infrastructure: SimNode,
+        *,
+        emit_idle: bool = True,
     ) -> BuildingNode | None:
         """Create a city at ``position`` and link it to ``last_infrastructure``.
 
@@ -64,6 +66,10 @@ class BuilderNode(WorkerNode):
         # Return to exploration after construction so the builder may seek
         # the next expansion target.
         self.state = "exploring"
+        if emit_idle:
+            # Notify systems that the builder finished its task so it can be
+            # assigned a new one by emitting ``unit_idle``.
+            self.emit("unit_idle", {}, direction="up")
         return city
 
     # ------------------------------------------------------------------
@@ -111,7 +117,7 @@ class BuilderNode(WorkerNode):
             prospective = set(path or [goal])
             if max_coverage is not None and len(covered | prospective) > max_coverage:
                 break
-            city = self.build_city(goal, current)
+            city = self.build_city(goal, current, emit_idle=False)
             if city is None:
                 break
             built.append(city)

--- a/systems/ai.py
+++ b/systems/ai.py
@@ -75,7 +75,7 @@ class AISystem(SystemNode):
                     dx = x0 - lx
                     dy = y0 - ly
                     if dx * dx + dy * dy >= self.capital_min_radius * self.capital_min_radius:
-                        city = origin.build_city([x0, y0], last)
+                        city = origin.build_city([x0, y0], last, emit_idle=False)
                         if city is not None:
                             self._last_city[key] = city
                             origin.emit("unit_idle", {}, direction="up")

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,3 +1,4 @@
+from core.simnode import SimNode
 from nodes.world import WorldNode
 from nodes.worker import WorkerNode
 from nodes.builder import BuilderNode
@@ -57,6 +58,21 @@ def test_builder_constructs_city_when_idle_far_from_last():
                 positions.append(child.position)
     assert [3, 0] in positions
     assert builder.state == "moving"
+
+
+def test_build_city_resets_state_and_emits_idle():
+    world = WorldNode(width=10, height=10)
+    builder = BuilderNode(parent=world, state="building")
+    last = BuildingNode(parent=world, type="city")
+    TransformNode(parent=last, position=[0, 0])
+
+    events: list[SimNode] = []
+    world.on_event("unit_idle", lambda origin, _e, _p: events.append(origin))
+
+    builder.build_city([1, 0], last)
+
+    assert builder.state == "exploring"
+    assert builder in events
 
 
 def test_ai_initializes_last_city_with_capital():


### PR DESCRIPTION
## Summary
- make `build_city` optionally emit a `unit_idle` signal after constructing a city
- avoid recursive loops in `AISystem` by suppressing automatic emission during city creation and re-emitting afterwards
- add regression test covering builder idle emission

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a394a6651083308e7bbb8852f5440c