### PR TITLE
Add movement and time systems to colony config

### DIFF
--- a/example/colony_config.json
+++ b/example/colony_config.json
@@ -7,6 +7,8 @@
       "seed": 1
     },
     "children": [
+      { "type": "TimeSystem", "id": "time", "config": { "time_scale": 48 } },
+      { "type": "MovementSystem", "id": "movement", "config": { "terrain": "terrain" } },
       {
         "type": "TerrainNode",
         "id": "terrain",
@@ -27,7 +29,7 @@
       {
         "type": "NationNode",
         "id": "north",
-        "config": { "capital_position": [500, 500] },
+        "config": { "capital_position": [500, 500], "morale": 100 },
         "children": [
           {
             "type": "GeneralNode",


### PR DESCRIPTION
## Summary
- enable simulation time progression and unit movement in the colony example
- ensure NationNode has required morale setting

## Testing
- `pytest`
- `timeout 3 python run_colony.py`


------
https://chatgpt.com/codex/tasks/task_e_68a39653ccc883308616d53b1e1abc6b