### PR TITLE
Spawn builder units and trigger AI exploration

### DIFF
--- a/example/colony_config.json
+++ b/example/colony_config.json
@@ -9,6 +9,10 @@
     "children": [
       { "type": "TimeSystem", "id": "time", "config": { "time_scale": 48 } },
       { "type": "MovementSystem", "id": "movement", "config": { "terrain": "terrain" } },
+      { "type": "VisibilitySystem", "id": "visibility" },
+      { "type": "SchedulerSystem", "id": "scheduler" },
+      { "type": "PathfindingSystem", "id": "pathfinder", "config": { "terrain": "terrain" } },
+      { "type": "AISystem", "id": "ai", "config": { "exploration_radius": 10, "capital_min_radius": 50 } },
       {
         "type": "TerrainNode",
         "id": "terrain",
@@ -35,6 +39,30 @@
             "type": "GeneralNode",
             "id": "north_general",
             "config": { "style": "balanced" },
+            "children": [
+              { "type": "TransformNode", "config": { "position": [500, 500] } }
+            ]
+          },
+          {
+            "type": "BuilderNode",
+            "id": "builder1",
+            "config": { "speed": 10.0 },
+            "children": [
+              { "type": "TransformNode", "config": { "position": [500, 500] } }
+            ]
+          },
+          {
+            "type": "BuilderNode",
+            "id": "builder2",
+            "config": { "speed": 10.0 },
+            "children": [
+              { "type": "TransformNode", "config": { "position": [500, 500] } }
+            ]
+          },
+          {
+            "type": "BuilderNode",
+            "id": "builder3",
+            "config": { "speed": 10.0 },
             "children": [
               { "type": "TransformNode", "config": { "position": [500, 500] } }
             ]

--- a/nodes/worker.py
+++ b/nodes/worker.py
@@ -26,6 +26,7 @@ class WorkerNode(UnitNode):
         self._manual_update = True
         self.on_event("task_assigned", self._on_task_assigned)
         self.on_event("task_complete", self._on_task_complete)
+        self.emit("unit_idle", {}, direction="up")
 
     # ------------------------------------------------------------------
     def _find_scheduler(self) -> SchedulerSystem | None:


### PR DESCRIPTION
## Summary
- expand colony config with AI, scheduling, pathfinding, and visibility systems
- spawn three builder units at the capital with increased speed
- emit initial `unit_idle` from workers to kick off AI exploration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a39981f3fc8330b77e0d9974254859