### PR TITLE
Increase AI exploration radius in colony config

### DIFF
--- a/example/colony_config.json
+++ b/example/colony_config.json
@@ -7,12 +7,12 @@
       "seed": 1
     },
     "children": [
-      { "type": "TimeSystem", "id": "time", "config": { "time_scale": 48 } },
+      { "type": "TimeSystem", "id": "time", "config": { "time_scale": 10 } },
       { "type": "MovementSystem", "id": "movement", "config": { "terrain": "terrain" } },
       { "type": "VisibilitySystem", "id": "visibility" },
       { "type": "SchedulerSystem", "id": "scheduler" },
       { "type": "PathfindingSystem", "id": "pathfinder", "config": { "terrain": "terrain" } },
-      { "type": "AISystem", "id": "ai", "config": { "exploration_radius": 10, "capital_min_radius": 50 } },
+      { "type": "AISystem", "id": "ai", "config": { "exploration_radius": 60, "capital_min_radius": 50 } },
       {
         "type": "TerrainNode",
         "id": "terrain",


### PR DESCRIPTION
## Summary
- expand `exploration_radius` to exceed `capital_min_radius` so AI can find valid destinations
- slow down simulation by reducing `TimeSystem` `time_scale` for easier visual tracking

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3a37660f083309892886c13b780ba