### PR TITLE
Emit unit_idle when unit stops moving

### DIFF
--- a/systems/movement.py
+++ b/systems/movement.py
@@ -162,6 +162,7 @@ class MovementSystem(SystemNode):
                     continue
                 unit.state = "idle"
                 tile_units.setdefault((sx, sy), []).append(unit)
+                unit.emit("unit_idle", {}, direction="up")
                 continue
             speed = unit.speed
             terrain = self.terrain


### PR DESCRIPTION
## Summary
- Emit unit_idle event when a unit reaches its destination without remaining path

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a42cf4c08330890e453ebd022d92