### PR TITLE
feat: spawn builders periodically

### DIFF
--- a/docs/global_spec.md
+++ b/docs/global_spec.md
@@ -100,6 +100,10 @@ La méthode `find_task()` sélectionne la ressource disponible la plus proche gr
 
 Voir `workers.md` pour une documentation d'utilisation détaillée.
 
+### `BuilderNode`
+Spécialisation de `WorkerNode` capable de fonder des villes et de relier les routes.
+L'`AISystem` peut en créer automatiquement à intervalles réguliers.
+
 ---
 
 ## Systèmes
@@ -116,9 +120,13 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 ### `SchedulerSystem`
 - Exécute les mises à jour d'unités selon un intervalle (`n` secondes) au lieu de chaque tick.
 - Les ouvriers inactifs sont désinscrits du scheduler.
+- Les unités ajoutées dynamiquement sont inscrites dès qu'une tâche leur est assignée.
 
 ### `AISystem`
 - Réagit à `unit_idle` pour chercher une nouvelle tâche via `find_task()`.
+- Peut générer un `BuilderNode` à la capitale de chaque nation toutes les
+  `builder_spawn_interval` secondes et émet immédiatement `unit_idle` pour
+  qu'il soit pris en charge.
 - Stratégies :
   - **Recherche de ressource** la plus proche en utilisant `systems.pathfinding`.
   - **Exploration** de coordonnées inconnues dans un rayon donné en émettant `unit_move`.

--- a/simulation/war/presets.py
+++ b/simulation/war/presets.py
@@ -8,6 +8,8 @@ DEFAULT_SIM_PARAMS = {
     "bodyguard_size": 5,
     "vision_radius_m": 100.0,
     "movement_blocking": True,
+    # Interval in seconds between automatic builder spawns per nation
+    "builder_spawn_interval": 0.0,
 }
 
 RIVER_WIDTH_PRESETS = [(2, 5), (4, 8), (8, 14)]

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -80,8 +80,6 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     config_file = config_file or "example/flat_1km_config.json"
     world = load_simulation_from_file(config_file)
 
-    AISystem(parent=world, capital_min_radius=100)
-
     terrain_node = next((c for c in world.children if isinstance(c, TerrainNode)), None)
     terrain_params = dict(getattr(terrain_node, "params", {})) if terrain_node else {}
     terrain_params.setdefault("forests", {"total_area_pct": 10, "clusters": 5, "cluster_spread": 0.5})
@@ -95,6 +93,13 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     settings_file = settings_file or (sys.argv[2] if len(sys.argv) > 2 else "example/war_settings.json")
     sim_params.update(load_sim_params(settings_file))
     sim_params["terrain"] = terrain_params
+
+    AISystem(
+        parent=world,
+        capital_min_radius=100,
+        builder_spawn_interval=sim_params.get("builder_spawn_interval", 0.0),
+    )
+
     return world, terrain_node, pathfinder
 
 

--- a/tests/test_builder_spawn_interval.py
+++ b/tests/test_builder_spawn_interval.py
@@ -1,0 +1,29 @@
+from nodes.world import WorldNode
+from nodes.nation import NationNode
+from systems.ai import AISystem
+from systems.scheduler import SchedulerSystem
+from nodes.builder import BuilderNode
+from nodes.transform import TransformNode
+
+
+def test_ai_spawns_builder_and_scheduler_handles_it():
+    world = WorldNode(width=100, height=100)
+    nation = NationNode(parent=world, morale=100, capital_position=[0, 0])
+    scheduler = SchedulerSystem(parent=world)
+    AISystem(parent=world, builder_spawn_interval=1.0)
+
+    # No builders initially
+    assert not [c for c in nation.children if isinstance(c, BuilderNode)]
+
+    # After one second a builder should spawn at the capital
+    world.update(1.0)
+    builders = [c for c in nation.children if isinstance(c, BuilderNode)]
+    assert len(builders) == 1
+    builder = builders[0]
+    tr = next(c for c in builder.children if isinstance(c, TransformNode))
+    assert tr.position == [0, 0]
+
+    # Scheduler should register the builder once a task is assigned
+    assert scheduler._tasks == []
+    builder.emit("task_assigned", {"task": "build"})
+    assert any(t.node is builder for t in scheduler._tasks)


### PR DESCRIPTION
## Summary
- document periodic builder spawning and dynamic scheduling
- spawn BuilderNode for each nation on a configurable interval
- test that new builders register with SchedulerSystem

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48cdc5504833089580fdfe504e52d