### PR TITLE
Enforce city influence radius for expansion

### DIFF
--- a/docs/global_spec.md
+++ b/docs/global_spec.md
@@ -144,6 +144,10 @@ Les systèmes encapsulent des règles de jeu spécifiques et écoutent les messa
 - Détecte la capture de la capitale et l'effondrement moral.
 - Écoute `building_destroyed` pour déclarer la défaite lorsqu'un bâtiment stratégique est perdu.
 
+### Croissance du royaume
+- Chaque nation maintient une liste `cities_positions` contenant les coordonnées de toutes ses cités, capitale incluse.
+- La construction d'une nouvelle cité est refusée si elle se trouve à moins de `city_influence_radius` d'une cité existante.
+
 ---
 
 ## Événements principaux

--- a/nodes/nation.py
+++ b/nodes/nation.py
@@ -1,7 +1,7 @@
 """Nation node representing a faction in the war simulation."""
 from __future__ import annotations
 
-from typing import List
+from typing import List, Tuple
 
 from core.simnode import SimNode
 from core.plugins import register_node_type
@@ -18,10 +18,17 @@ class NationNode(SimNode):
         ``[x, y]`` coordinates of the nation's capital.
     """
 
-    def __init__(self, morale: int, capital_position: List[int], **kwargs) -> None:
+    def __init__(
+        self, morale: int, capital_position: List[int], **kwargs
+    ) -> None:
+        city_radius = kwargs.pop("city_influence_radius", 0)
         super().__init__(**kwargs)
         self.morale = morale
         self.capital_position = capital_position
+        self.city_influence_radius = city_radius
+        self.cities_positions: List[Tuple[float, float]] = [
+            (float(capital_position[0]), float(capital_position[1]))
+        ]
 
     # ------------------------------------------------------------------
     def change_morale(self, delta: int) -> None:

--- a/simulation/war/presets.py
+++ b/simulation/war/presets.py
@@ -8,6 +8,7 @@ DEFAULT_SIM_PARAMS = {
     "bodyguard_size": 5,
     "vision_radius_m": 100.0,
     "movement_blocking": True,
+    "city_influence_radius": 50,
 }
 
 RIVER_WIDTH_PRESETS = [(2, 5), (4, 8), (8, 14)]

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -80,7 +80,11 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     config_file = config_file or "example/flat_1km_config.json"
     world = load_simulation_from_file(config_file)
 
-    AISystem(parent=world, capital_min_radius=100)
+    ai = AISystem(
+        parent=world,
+        capital_min_radius=100,
+        city_influence_radius=sim_params.get("city_influence_radius", 0),
+    )
 
     terrain_node = next((c for c in world.children if isinstance(c, TerrainNode)), None)
     terrain_params = dict(getattr(terrain_node, "params", {})) if terrain_node else {}
@@ -92,9 +96,16 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     if pathfinder is None:
         pathfinder = PathfindingSystem(parent=world, terrain=terrain_node)
 
-    settings_file = settings_file or (sys.argv[2] if len(sys.argv) > 2 else "example/war_settings.json")
+    settings_file = settings_file or (
+        sys.argv[2] if len(sys.argv) > 2 else "example/war_settings.json"
+    )
     sim_params.update(load_sim_params(settings_file))
     sim_params["terrain"] = terrain_params
+
+    ai.city_influence_radius = sim_params.get("city_influence_radius", 0)
+    for nation in [n for n in world.children if isinstance(n, NationNode)]:
+        nation.city_influence_radius = sim_params.get("city_influence_radius", 0)
+
     return world, terrain_node, pathfinder
 
 


### PR DESCRIPTION
## Summary
- Track each nation's city locations and influence radius
- Reject new cities built within the influence radius of existing ones
- Add default `city_influence_radius` sim parameter and propagate it to AI and nations
- Return builders to exploration when blocked by an existing city's influence
- Test builder city placement logic and influence radius handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a48cdfeb248330ba350eb0c5fda9e9