### PR TITLE
Prevent placeholder city node at capital spawn

### DIFF
--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -104,14 +104,9 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     sim_params["terrain"] = terrain_params
 
     ai.city_influence_radius = sim_params.get("city_influence_radius", 0)
+    ai.builder_spawn_interval = sim_params.get("builder_spawn_interval", 0.0)
     for nation in [n for n in world.children if isinstance(n, NationNode)]:
         nation.city_influence_radius = sim_params.get("city_influence_radius", 0)
-
-    AISystem(
-        parent=world,
-        capital_min_radius=100,
-        builder_spawn_interval=sim_params.get("builder_spawn_interval", 0.0),
-    )
 
 
     return world, terrain_node, pathfinder

--- a/systems/ai.py
+++ b/systems/ai.py
@@ -82,7 +82,7 @@ class AISystem(SystemNode):
             key = id(nation)
             if key in self._last_city:
                 continue
-            city = BuildingNode(parent=root, type="city")
+            city = BuildingNode(type="city")
             TransformNode(parent=city, position=list(nation.capital_position))
             self._last_city[key] = city
 
@@ -101,10 +101,7 @@ class AISystem(SystemNode):
                 key = id(nation)
                 last = self._last_city.get(key)
                 if last is None:
-                    root = self
-                    while root.parent is not None:
-                        root = root.parent
-                    last = BuildingNode(parent=root, type="city")
+                    last = BuildingNode(type="city")
                     TransformNode(parent=last, position=list(nation.capital_position))
                     self._last_city[key] = last
                 last_tr = self._get_transform(last)


### PR DESCRIPTION
## Summary
- Avoid attaching placeholder city nodes for capitals so no stray markers appear
- Reuse the AISystem in `setup_world` instead of spawning a duplicate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a49fc423908330a7e1d45394db18f1