### PR TITLE
Ensure scheduler handles spawned builders

### DIFF
--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -20,6 +20,7 @@ from simulation.war.nodes import (
 )
 from nodes.builder import BuilderNode
 from systems.ai import AISystem
+from systems.scheduler import SchedulerSystem
 from simulation.war.presets import DEFAULT_SIM_PARAMS
 from simulation.war.systems import MovementSystem, PathfindingSystem
 from simulation.war.terrain_setup import terrain_regen
@@ -56,6 +57,7 @@ def load_plugins_for_war() -> None:
             "systems.victory",
             "systems.time",
             "systems.logger",
+            "systems.scheduler",
             "systems.ai",
         ]
     )
@@ -85,6 +87,12 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
         capital_min_radius=100,
         city_influence_radius=sim_params.get("city_influence_radius", 0),
     )
+
+    # Ensure a SchedulerSystem is present so that newly spawned workers can be
+    # registered for periodic updates. If one is already defined in the config
+    # file it is reused, otherwise we create it here.
+    if not any(isinstance(c, SchedulerSystem) for c in world.children):
+        SchedulerSystem(parent=world)
 
 
     terrain_node = next((c for c in world.children if isinstance(c, TerrainNode)), None)
@@ -150,7 +158,7 @@ def _spawn_armies(
             )
             builder.add_child(TransformNode(position=list(center)))
             nation.add_child(builder)
-            builder.emit("unit_idle", {})
+            builder.emit("unit_idle", {}, direction="up")
 
 
 

--- a/systems/ai.py
+++ b/systems/ai.py
@@ -1,6 +1,7 @@
 """Simple AI system reacting to idle units."""
 from __future__ import annotations
 
+import logging
 import random
 
 from core.simnode import SystemNode, SimNode
@@ -13,6 +14,8 @@ from nodes.nation import NationNode
 from nodes.unit import UnitNode
 from nodes.terrain import TerrainNode
 from systems.visibility import VisibilitySystem
+
+logger = logging.getLogger(__name__)
 
 
 class AISystem(SystemNode):
@@ -69,7 +72,8 @@ class AISystem(SystemNode):
                         TransformNode(position=list(nation.capital_position))
                     )
                     nation.add_child(builder)
-                    builder.emit("unit_idle", {})
+                    logger.info("Spawned builder %s for %s", builder.name, nation.name)
+                    builder.emit("unit_idle", {}, direction="up")
         super().update(dt)
 
     # ------------------------------------------------------------------
@@ -147,6 +151,7 @@ class AISystem(SystemNode):
                 origin.target = [pos[0], pos[1]]
                 origin.state = "moving"
                 origin.emit("unit_move", {"to": origin.target}, direction="up")
+                logger.info("%s moving to %s", getattr(origin, "name", "unit"), origin.target)
                 return
         # fallback random move if everything explored
         for _ in range(10):
@@ -160,6 +165,7 @@ class AISystem(SystemNode):
             origin.target = [pos[0], pos[1]]
             origin.state = "moving"
             origin.emit("unit_move", {"to": origin.target}, direction="up")
+            logger.info("%s moving to %s", getattr(origin, "name", "unit"), origin.target)
             return
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- load SchedulerSystem for war simulations and create one if missing
- spawn builders with upward unit_idle events and debug logging
- trace initial builder movement for easier verification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a13040048330bcf1d5a97d4e2ccf