### PR TITLE
Add wandering exploration and remove debug arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After installing the dependencies, launch the Pygame-powered example farm:
 python run_farm.py
 ```
 
-The window renders terrain tiles, unit icons and yellow arrows pointing to their movement targets.
+The window renders terrain tiles and unit icons.
 
 The viewer opens centered on the battlefield with a compact sidebar so troop
 movement is immediately visible.

--- a/docs/checklists/war_simulation_roadmap.md
+++ b/docs/checklists/war_simulation_roadmap.md
@@ -36,7 +36,7 @@ This roadmap breaks down the tasks required to build the simplified war simulati
 
 ## Visualization Enhancements (Later Iterations)
  - [x] **Zoom and inspect** – Ability to zoom into specific units or armies.
- - [x] **Clear map overlay** – Show terrain types, unit icons and movement arrows.
+- [x] **Clear map overlay** – Show terrain types and unit icons.
 - [ ] **Optional hex grid rendering** – If hex grid adopted, update visualization accordingly.
 
 ## Extensions & Analysis

--- a/simulation/war/presets.py
+++ b/simulation/war/presets.py
@@ -11,6 +11,10 @@ DEFAULT_SIM_PARAMS = {
 
     "city_influence_radius": 50,
 
+    # Random wander parameters for idle units
+    "wander_drift": 0.1,
+    "wander_speed": 1.0,
+
     # Interval in seconds between automatic builder spawns per nation
     "builder_spawn_interval": 0.0,
 

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -189,4 +189,6 @@ def reset_world(world, pathfinder: PathfindingSystem | None = None) -> MovementS
     movement_system = next((c for c in world.children if isinstance(c, MovementSystem)), None)
     if movement_system:
         movement_system.set_blocking(sim_params.get("movement_blocking", True))
+        movement_system.wander_drift = sim_params.get("wander_drift", movement_system.wander_drift)
+        movement_system.wander_speed = sim_params.get("wander_speed", movement_system.wander_speed)
     return movement_system

--- a/systems/ai.py
+++ b/systems/ai.py
@@ -133,40 +133,8 @@ class AISystem(SystemNode):
                                 self._last_city[key] = city
                                 origin.emit("unit_idle", {}, direction="up")
                             return
-        x0 = int(round(transform.position[0]))
-        y0 = int(round(transform.position[1]))
-        radius = self.exploration_radius
-        explored = self._get_explored(origin)
-        for dx in range(-radius, radius + 1):
-            for dy in range(-radius, radius + 1):
-                if dx * dx + dy * dy > radius * radius:
-                    continue
-                pos = (x0 + dx, y0 + dy)
-                if pos in explored:
-                    continue
-                if not self._beyond_capital_radius(origin, pos):
-                    continue
-                if not self._is_free(pos):
-                    continue
-                origin.target = [pos[0], pos[1]]
-                origin.state = "moving"
-                origin.emit("unit_move", {"to": origin.target}, direction="up")
-                logger.info("%s moving to %s", getattr(origin, "name", "unit"), origin.target)
-                return
-        # fallback random move if everything explored
-        for _ in range(10):
-            dx = random.randint(-radius, radius)
-            dy = random.randint(-radius, radius)
-            pos = (x0 + dx, y0 + dy)
-            if not self._beyond_capital_radius(origin, pos):
-                continue
-            if not self._is_free(pos):
-                continue
-            origin.target = [pos[0], pos[1]]
-            origin.state = "moving"
-            origin.emit("unit_move", {"to": origin.target}, direction="up")
-            logger.info("%s moving to %s", getattr(origin, "name", "unit"), origin.target)
-            return
+        origin.state = "exploring"
+        origin.target = None
 
     # ------------------------------------------------------------------
     def _get_transform(self, node: SimNode) -> TransformNode | None:

--- a/systems/pygame_viewer.py
+++ b/systems/pygame_viewer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import time
 import logging
-from math import atan2, cos, sin, pi, ceil
+from math import ceil
 from typing import Any, Callable, Iterator, List, Optional, Tuple, Protocol
 
 import pygame
@@ -36,9 +36,6 @@ TERRAIN_COLORS: dict[int, Tuple[int, int, int]] = {
     TILE_CODES["desert"]: (210, 180, 140),
     TILE_CODES["road"]: (120, 120, 120),
 }
-ARROW_COLOR = (255, 255, 0)
-# Shorter arrows for unit targets
-ARROW_MAX_LEN = 25
 CAPITAL_COLOR = (0, 200, 0)
 NATION_COLORS = [
     (200, 50, 50),
@@ -294,28 +291,6 @@ class PygameViewerSystem(SystemNode, Viewer):
             cur = cur.parent
         return None
 
-    def _draw_arrow(
-        self, start: Tuple[int, int], end: Tuple[int, int], color: Tuple[int, int, int]
-    ) -> None:
-        dx, dy = end[0] - start[0], end[1] - start[1]
-        dist = (dx ** 2 + dy ** 2) ** 0.5
-        if dist > ARROW_MAX_LEN:
-            scale = ARROW_MAX_LEN / dist
-            end = (start[0] + dx * scale, start[1] + dy * scale)
-            dx, dy = end[0] - start[0], end[1] - start[1]
-        pygame.draw.line(self.screen, color, start, end, 2)
-        angle = atan2(dy, dx)
-        size = 6
-        left = (
-            end[0] - size * cos(angle - pi / 6),
-            end[1] - size * sin(angle - pi / 6),
-        )
-        right = (
-            end[0] - size * cos(angle + pi / 6),
-            end[1] - size * sin(angle + pi / 6),
-        )
-        pygame.draw.polygon(self.screen, color, [end, left, right])
-
     def _draw_cross(self, center: Tuple[int, int], size: int) -> None:
         """Draw a cross centered on ``center`` with given ``size``."""
         x, y = center
@@ -424,12 +399,6 @@ class PygameViewerSystem(SystemNode, Viewer):
                 if isinstance(parent, UnitNode):
                     col = nation_colors.get(self._nation_of(parent), (200, 200, 200))
                     target = getattr(parent, "target", None)
-                    if target is not None and parent.state != "defeated":
-                        end = (
-                            int((target[0] - self.offset_x) * self.scale),
-                            int((target[1] - self.offset_y) * self.scale),
-                        )
-                        self._draw_arrow(pos, end, ARROW_COLOR)
                     radius = int(
                         self.unit_radius
                         * max(


### PR DESCRIPTION
## Summary
- Implement per-unit wandering angles with random drift and capital avoidance
- Simplify AI idle handling to put units into exploring state
- Remove debug movement arrows and expose wander parameters in presets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a32a161483309bc9a7d9592f682a