### PR TITLE
Add builder spawn interval setting to war example

### DIFF
--- a/example/war_settings.json
+++ b/example/war_settings.json
@@ -7,7 +7,8 @@
     "vision_radius_m": 100.0,
     "visibility": true,
     "command_delay": 0.0,
-    "movement_blocking": true
+    "movement_blocking": true,
+    "builder_spawn_interval": 5.0
   },
   "descriptions": {
     "dispersion": "Max distance from the nation's capital when spawning units (meters)",
@@ -17,6 +18,7 @@
     "vision_radius_m": "Unit vision radius in meters for fog of war calculations",
     "visibility": "Enable fog of war via the VisibilitySystem",
     "command_delay": "Base seconds commands are delayed before reaching units",
-    "movement_blocking": "Whether units block each other during movement"
+    "movement_blocking": "Whether units block each other during movement",
+    "builder_spawn_interval": "Seconds between automatic builder spawns per nation"
   }
 }


### PR DESCRIPTION
## Summary
- expose `builder_spawn_interval` in `example/war_settings.json`
- document builder spawn interval description

## Testing
- `python - <<'PY'
from simulation.war.war_loader import setup_world, reset_world, load_plugins_for_war
from nodes.nation import NationNode
from nodes.builder import BuilderNode

load_plugins_for_war()
world, terrain_node, pathfinder = setup_world(settings_file="example/war_settings.json")
reset_world(world, pathfinder)

for i in range(6):
    world.update(1.0)
    builders = sum(1 for n in world.children if isinstance(n, NationNode) for c in n.children if isinstance(c, BuilderNode))
    print(f"t={i+1}, builders={builders}")
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a938f90883308e4403129dbbb424