### PR TITLE
Clean up old builders before spawning new ones

### DIFF
--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -149,6 +149,10 @@ def _spawn_armies(
         strategist = StrategistNode(name=f"{nation.name}_strategist")
         general.add_child(strategist)
 
+        for child in list(nation.children):
+            if isinstance(child, BuilderNode):
+                nation.remove_child(child)
+
         for i in range(3):
             builder = BuilderNode(
                 name=f"{nation.name}_builder_{i+1}",


### PR DESCRIPTION
## Summary
- Remove existing `BuilderNode` children from each nation before spawning new builders
- Continue spawning three fresh builders and trigger `unit_idle` for each

## Testing
- `pytest`
- `python run_colony.py` *(interrupted after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a90cc1d88330a69c5ac5189fc53d