### PR TITLE
Start viewer paused and disable default army spawn

### DIFF
--- a/example/colony_config.json
+++ b/example/colony_config.json
@@ -42,30 +42,6 @@
             "children": [
               { "type": "TransformNode", "config": { "position": [500, 500] } }
             ]
-          },
-          {
-            "type": "BuilderNode",
-            "id": "builder1",
-            "config": { "speed": 10.0 },
-            "children": [
-              { "type": "TransformNode", "config": { "position": [500, 500] } }
-            ]
-          },
-          {
-            "type": "BuilderNode",
-            "id": "builder2",
-            "config": { "speed": 10.0 },
-            "children": [
-              { "type": "TransformNode", "config": { "position": [500, 500] } }
-            ]
-          },
-          {
-            "type": "BuilderNode",
-            "id": "builder3",
-            "config": { "speed": 10.0 },
-            "children": [
-              { "type": "TransformNode", "config": { "position": [500, 500] } }
-            ]
           }
         ]
       }

--- a/simulation/war/viewer_loop.py
+++ b/simulation/war/viewer_loop.py
@@ -53,7 +53,7 @@ def run(viewer: str = "pygame") -> None:
     TIME_SCALE = config.TIME_SCALE
     clock = pygame.time.Clock()
 
-    paused = False
+    paused = True
     running = True
     while running and pygame.get_init():
         events = pygame.event.get()

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -167,7 +167,7 @@ def _spawn_armies(
 
 
 def reset_world(world, pathfinder: PathfindingSystem | None = None) -> MovementSystem | None:
-    """Reset terrain and spawn armies using current ``sim_params``."""
+    """Reset terrain using current ``sim_params`` without spawning armies."""
 
     cache_path = os.environ.get("WAR_TERRAIN_CACHE")
     if cache_path and os.path.exists(cache_path):
@@ -183,13 +183,7 @@ def reset_world(world, pathfinder: PathfindingSystem | None = None) -> MovementS
             sim_params["terrain"] = data.get("params", {})
     else:
         terrain_regen(world, sim_params["terrain"])
-    _spawn_armies(
-        world,
-        sim_params["dispersion"],
-        sim_params["soldiers_per_dot"],
-        sim_params["bodyguard_size"],
-        pathfinder,
-    )
+    # Armies are no longer spawned automatically to start with an empty world
     movement_system = next((c for c in world.children if isinstance(c, MovementSystem)), None)
     if movement_system:
         movement_system.set_blocking(sim_params.get("movement_blocking", True))


### PR DESCRIPTION
## Summary
- Start viewer with simulation paused so time advances only after pressing space
- Stop spawning armies automatically during world reset and remove builder units from example config
- Trim colony config to nation and capital only

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ae92ffe083309f4832474cfc7fa7