### PR TITLE
Add hotkey to spawn builder at capital

### DIFF
--- a/simulation/war/viewer_loop.py
+++ b/simulation/war/viewer_loop.py
@@ -9,6 +9,7 @@ import config
 from simulation.war.ui import ModernGLViewerSystem, PygameViewerSystem
 from simulation.war.war_loader import (
     load_plugins_for_war,
+    spawn_builder,
     reset_world,
     setup_world,
 )
@@ -91,6 +92,8 @@ def run(viewer: str = "pygame") -> None:
                     viewer.offset_y += viewer.view_height * 0.1 / viewer.scale
                 elif event.key == pygame.K_z:
                     viewer.offset_y -= viewer.view_height * 0.1 / viewer.scale
+                elif event.key == pygame.K_u:
+                    spawn_builder(world)
                 # no additional controls when paused
 
         viewer.extra_info = []

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -120,6 +120,27 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
     return world, terrain_node, pathfinder
 
 
+def spawn_builder(world) -> BuilderNode | None:
+    """Spawn a :class:`BuilderNode` at the capital of the main nation."""
+
+    nation = next((c for c in world.children if isinstance(c, NationNode)), None)
+    if nation is None:
+        return None
+
+    capital = getattr(nation, "capital_position", [world.width / 2, world.height / 2])
+    count = sum(1 for c in nation.children if isinstance(c, BuilderNode))
+    builder = BuilderNode(
+        name=f"{nation.name}_builder_{count + 1}",
+        state="exploring",
+        speed=1.0,
+        morale=100,
+    )
+    builder.add_child(TransformNode(position=list(capital)))
+    nation.add_child(builder)
+    builder.emit("unit_idle", {}, direction="up")
+    return builder
+
+
 def _spawn_armies(
     world,
     dispersion_radius: float,


### PR DESCRIPTION
## Summary
- Add `spawn_builder` utility to create an exploring BuilderNode at the nation's capital and trigger AI handling
- Bind the `u` key in the viewer to spawn a builder on demand

## Testing
- `python - <<'PY'
from simulation.war.war_loader import load_plugins_for_war, setup_world, spawn_builder
from nodes.builder import BuilderNode
from nodes.nation import NationNode

load_plugins_for_war()
world, _, _ = setup_world()

nation = next(c for c in world.children if isinstance(c, NationNode))
print('builders before', len([c for c in nation.children if isinstance(c, BuilderNode)]))
spawn_builder(world)
print('builders after', len([c for c in nation.children if isinstance(c, BuilderNode)]))
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4af4b01808330a4bd97770736948a