### PR TITLE
Implement timed city construction and return roads for builders

### DIFF
--- a/simulation/war/presets.py
+++ b/simulation/war/presets.py
@@ -10,6 +10,8 @@ DEFAULT_SIM_PARAMS = {
     "movement_blocking": True,
 
     "city_influence_radius": 50,
+    "capital_min_radius": 100,
+    "build_duration": 5.0,
 
     # Random wander parameters for idle units
     "wander_drift": 0.1,

--- a/simulation/war/war_loader.py
+++ b/simulation/war/war_loader.py
@@ -84,8 +84,9 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
 
     ai = AISystem(
         parent=world,
-        capital_min_radius=100,
+        capital_min_radius=sim_params.get("capital_min_radius", 0),
         city_influence_radius=sim_params.get("city_influence_radius", 0),
+        build_duration=sim_params.get("build_duration", 0.0),
     )
 
     # Ensure a SchedulerSystem is present so that newly spawned workers can be
@@ -113,6 +114,7 @@ def setup_world(config_file: str | None = None, settings_file: str | None = None
 
     ai.city_influence_radius = sim_params.get("city_influence_radius", 0)
     ai.builder_spawn_interval = sim_params.get("builder_spawn_interval", 0.0)
+    ai.build_duration = sim_params.get("build_duration", 0.0)
     for nation in [n for n in world.children if isinstance(n, NationNode)]:
         nation.city_influence_radius = sim_params.get("city_influence_radius", 0)
 
@@ -134,6 +136,7 @@ def spawn_builder(world) -> BuilderNode | None:
         state="exploring",
         speed=1.0,
         morale=100,
+        build_duration=sim_params.get("build_duration", 0.0),
     )
     builder.add_child(TransformNode(position=list(capital)))
     nation.add_child(builder)
@@ -180,6 +183,7 @@ def _spawn_armies(
                 state="exploring",
                 speed=1.0,
                 morale=100,
+                build_duration=sim_params.get("build_duration", 0.0),
             )
             builder.add_child(TransformNode(position=list(center)))
             nation.add_child(builder)

--- a/tests/test_builder_spawn_interval.py
+++ b/tests/test_builder_spawn_interval.py
@@ -10,7 +10,7 @@ def test_ai_spawns_builder_and_scheduler_handles_it():
     world = WorldNode(width=100, height=100)
     nation = NationNode(parent=world, morale=100, capital_position=[0, 0])
     scheduler = SchedulerSystem(parent=world)
-    AISystem(parent=world, builder_spawn_interval=1.0)
+    AISystem(parent=world, builder_spawn_interval=1.0, capital_min_radius=10)
 
     # No builders initially
     assert not [c for c in nation.children if isinstance(c, BuilderNode)]


### PR DESCRIPTION
## Summary
- add build-duration tracking and return-road laying to `BuilderNode`
- extend `AISystem` to trigger timed construction and track new cities
- expose `build_duration` and `capital_min_radius` in simulation presets and loader
- update tests for builder exploration and automatic spawn scheduling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b02bca048330a2e9d0f1a6d75e97