### PR TITLE
Add full BuilderNode lifecycle with timed construction and cleanup

### DIFF
--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -76,15 +76,14 @@ def test_builder_constructs_city_when_idle_far_from_last():
             if isinstance(child, TransformNode):
                 positions.append(child.position)
     assert [3, 0] in positions
-    tr = next(c for c in builder.children if isinstance(c, TransformNode))
-    assert tr.position == [0.0, 0.0]
     road_positions = sorted(
         child.children[0].position
         for child in world.children
         if isinstance(child, BuildingNode) and child.type == "road"
     )
     assert road_positions == [[1, 0], [2, 0]]
-    assert builder.state == "exploring"
+    assert builder.parent is None
+    assert builder not in nation.children
 
 
 def test_build_city_resets_state_and_emits_idle():


### PR DESCRIPTION
## Summary
- Default build duration now pulled from simulation parameters (7200s fallback)
- Builders lay roads while returning to capital and are removed on arrival without emitting idle events
- Adjusted AI test to expect builder disappearance after returning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4bc576f608330865a6550647a6a09